### PR TITLE
Implement AI pipeline orchestration

### DIFF
--- a/backend/sql/04_ai_pipeline_schema.sql
+++ b/backend/sql/04_ai_pipeline_schema.sql
@@ -1,0 +1,103 @@
+-- AI pipeline schema alignment migration
+START TRANSACTION;
+
+ALTER TABLE unified_files
+    ADD COLUMN IF NOT EXISTS payment_type VARCHAR(255) NULL DEFAULT 'cash' AFTER orgnr,
+    ADD COLUMN IF NOT EXISTS purchase_datetime DATETIME NULL AFTER payment_type,
+    ADD COLUMN IF NOT EXISTS expense_type VARCHAR(255) NULL DEFAULT 'personal' AFTER purchase_datetime,
+    ADD COLUMN IF NOT EXISTS gross_amount_original DECIMAL(12,2) NULL AFTER expense_type,
+    ADD COLUMN IF NOT EXISTS net_amount_original DECIMAL(12,2) NULL AFTER gross_amount_original,
+    ADD COLUMN IF NOT EXISTS exchange_rate DECIMAL(12,6) NULL DEFAULT 1 AFTER net_amount_original,
+    ADD COLUMN IF NOT EXISTS currency VARCHAR(222) NULL DEFAULT 'SEK' AFTER exchange_rate,
+    ADD COLUMN IF NOT EXISTS gross_amount_sek DECIMAL(12,2) NULL AFTER currency,
+    ADD COLUMN IF NOT EXISTS net_amount_sek DECIMAL(12,2) NULL AFTER gross_amount_sek,
+    ADD COLUMN IF NOT EXISTS ocr_raw LONGTEXT NULL AFTER mime_type,
+    ADD COLUMN IF NOT EXISTS company_id INT NULL AFTER ocr_raw,
+    ADD COLUMN IF NOT EXISTS receipt_number VARCHAR(255) NULL AFTER company_id,
+    ADD COLUMN IF NOT EXISTS other_data LONGTEXT NULL AFTER receipt_number,
+    ADD COLUMN IF NOT EXISTS credit_card_match TINYINT(1) NOT NULL DEFAULT 0 AFTER other_data;
+
+CREATE TABLE IF NOT EXISTS companies (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(234) NOT NULL,
+    orgnr VARCHAR(22) NOT NULL UNIQUE,
+    address VARCHAR(222) NULL,
+    address2 VARCHAR(222) NULL,
+    zip VARCHAR(123) NULL,
+    city VARCHAR(234) NULL,
+    country VARCHAR(234) NULL,
+    phone VARCHAR(234) NULL,
+    www VARCHAR(234) NULL,
+    created_at TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS receipt_items (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    main_id VARCHAR(36) NOT NULL,
+    article_id VARCHAR(222) NULL,
+    name VARCHAR(222) NOT NULL,
+    number INT NOT NULL,
+    item_price_ex_vat DECIMAL(12,2) NOT NULL DEFAULT 0.00,
+    item_price_inc_vat DECIMAL(12,2) NOT NULL DEFAULT 0.00,
+    item_total_price_ex_vat DECIMAL(12,2) NOT NULL DEFAULT 0.00,
+    item_total_price_inc_vat DECIMAL(12,2) NOT NULL DEFAULT 0.00,
+    currency VARCHAR(11) NOT NULL DEFAULT 'SEK',
+    vat DECIMAL(12,2) NOT NULL DEFAULT 0.00,
+    vat_percentage DECIMAL(7,6) NOT NULL DEFAULT 0.000000,
+    created_at TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    INDEX idx_receipt_items_main (main_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS ai_accounting_proposals (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    receipt_id VARCHAR(36) NOT NULL,
+    account_code VARCHAR(32) NOT NULL,
+    debit DECIMAL(12,2) NOT NULL DEFAULT 0.00,
+    credit DECIMAL(12,2) NOT NULL DEFAULT 0.00,
+    vat_rate DECIMAL(7,2) NULL,
+    notes VARCHAR(255) NULL,
+    created_at TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    INDEX idx_ai_proposals_receipt (receipt_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS creditcard_invoice_items (
+    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    main_id BIGINT UNSIGNED NULL,
+    line_no INT NULL,
+    transaction_id VARCHAR(64) NULL,
+    purchase_date DATE NULL,
+    posting_date DATE NULL,
+    merchant_name VARCHAR(200) NULL,
+    merchant_city VARCHAR(100) NULL,
+    merchant_country CHAR(2) NULL,
+    mcc VARCHAR(4) NULL,
+    description TEXT NULL,
+    currency_original CHAR(3) NULL,
+    amount_original DECIMAL(13,2) NULL,
+    exchange_rate DECIMAL(18,6) NULL,
+    amount_sek DECIMAL(13,2) NULL,
+    vat_rate DECIMAL(5,2) NULL,
+    vat_amount DECIMAL(13,2) NULL,
+    net_amount DECIMAL(13,2) NULL,
+    gross_amount DECIMAL(13,2) NULL,
+    cost_center_override VARCHAR(100) NULL,
+    project_code VARCHAR(100) NULL,
+    created_at TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    INDEX idx_invoice_items_purchase_date (purchase_date),
+    INDEX idx_invoice_items_merchant (merchant_name)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS creditcard_receipt_matches (
+    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    receipt_id VARCHAR(36) NOT NULL,
+    invoice_item_id BIGINT UNSIGNED NOT NULL,
+    matched_amount DECIMAL(13,2) NULL,
+    matched_at TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY uniq_receipt_invoice (receipt_id, invoice_item_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+COMMIT;

--- a/backend/src/api/ai_processing.py
+++ b/backend/src/api/ai_processing.py
@@ -1,27 +1,31 @@
 """API endpoints for AI processing of receipts and documents."""
+from __future__ import annotations
+
 import logging
 from contextlib import closing
 from datetime import datetime
 from decimal import Decimal
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
-from flask import Blueprint, request, jsonify
+from flask import Blueprint, jsonify, request
+from pydantic import ValidationError
 
 from ..models.ai_processing import (
+    AccountingClassificationRequest,
+    AccountingClassificationResponse,
+    AccountingProposal,
+    BatchProcessingRequest,
+    BatchProcessingResponse,
+    Company,
+    CreditCardMatchRequest,
+    CreditCardMatchResponse,
+    DataExtractionRequest,
+    DataExtractionResponse,
     DocumentClassificationRequest,
     DocumentClassificationResponse,
     ExpenseClassificationRequest,
     ExpenseClassificationResponse,
-    DataExtractionRequest,
-    DataExtractionResponse,
-    AccountingClassificationRequest,
-    AccountingClassificationResponse,
-    CreditCardMatchRequest,
-    CreditCardMatchResponse,
-    BatchProcessingRequest,
-    BatchProcessingResponse,
-    UnifiedFileAIStatus,
-    AccountingProposal,
+    ReceiptItem,
 )
 from ..services.ai_service import AIService
 from ..services.db.connection import db_cursor, get_connection
@@ -29,395 +33,277 @@ from .middleware import auth_required
 
 logger = logging.getLogger(__name__)
 
-bp = Blueprint('ai_processing', __name__, url_prefix='/ai')
+bp = Blueprint("ai_processing", __name__, url_prefix="/ai")
+
+_AI_STAGE_STATUS = {
+    "AI1": "ai1_completed",
+    "AI2": "ai2_completed",
+    "AI3": "ai3_completed",
+    "AI4": "ai4_completed",
+    "AI5_TRUE": "ai5_completed",
+    "AI5_FALSE": "ai5_no_match",
+}
 
 
-@bp.route('/classify/document', methods=['POST'])
-@auth_required
-def classify_document():
-    """
-    AI1 - Document Type Classification
-    Analyzes OCR text/image to determine document type.
-    """
-    try:
-        data = request.get_json()
-        req = DocumentClassificationRequest(**data)
+# ---------------------------------------------------------------------------
+# Database helpers
+# ---------------------------------------------------------------------------
 
-        # Call AI service for classification
-        ai_service = AIService()
-        result = ai_service.classify_document(req)
+def _stage_status(stage: str, matched: Optional[bool] = None) -> str:
+    if stage == "AI5":
+        key = f"AI5_{str(bool(matched)).upper()}"
+        return _AI_STAGE_STATUS[key]
+    return _AI_STAGE_STATUS[stage]
 
-        # Update database with classification
-        with db_cursor() as cursor:
-            cursor.execute(
-                """
-                UPDATE unified_files
-                SET file_type = %s,
-                    ai_status = 'processing',
-                    ai_confidence = %s,
-                    updated_at = NOW()
-                WHERE id = %s
-                """,
-                (result.document_type, result.confidence, req.file_id),
-            )
 
-        response = DocumentClassificationResponse(
-            file_id=req.file_id,
-            document_type=result.document_type,
-            confidence=result.confidence,
-            reasoning=result.reasoning
+def _set_ai_stage(
+    cursor,
+    file_id: str,
+    stage: str,
+    confidence: Optional[float] = None,
+    matched: Optional[bool] = None,
+) -> None:
+    status_value = _stage_status(stage, matched)
+    if confidence is None:
+        cursor.execute(
+            "UPDATE unified_files SET ai_status = %s, updated_at = NOW() WHERE id = %s",
+            (status_value, file_id),
+        )
+    else:
+        cursor.execute(
+            """
+            UPDATE unified_files
+               SET ai_status = %s,
+                   ai_confidence = GREATEST(IFNULL(ai_confidence, 0), %s),
+                   updated_at = NOW()
+             WHERE id = %s
+            """,
+            (status_value, confidence, file_id),
+        )
+    if cursor.rowcount == 0:
+        raise ValueError(f"File {file_id} not found")
+
+
+def _ensure_company(cursor, company: Company) -> Optional[int]:
+    name = (company.name or "").strip() or None
+    orgnr = (company.orgnr or "").strip() or None
+    if not name and not orgnr:
+        return None
+
+    company_id: Optional[int] = None
+    if orgnr:
+        cursor.execute("SELECT id FROM companies WHERE orgnr = %s", (orgnr,))
+        row = cursor.fetchone()
+        if row:
+            company_id = int(row[0])
+    if company_id is None and name:
+        cursor.execute(
+            "SELECT id FROM companies WHERE name = %s ORDER BY id LIMIT 1",
+            (name,),
+        )
+        row = cursor.fetchone()
+        if row:
+            company_id = int(row[0])
+
+    if company_id is not None:
+        cursor.execute(
+            """
+            UPDATE companies
+               SET name = COALESCE(%s, name),
+                   address = COALESCE(%s, address),
+                   address2 = COALESCE(%s, address2),
+                   zip = COALESCE(%s, zip),
+                   city = COALESCE(%s, city),
+                   country = COALESCE(%s, country),
+                   phone = COALESCE(%s, phone),
+                   www = COALESCE(%s, www),
+                   updated_at = NOW()
+             WHERE id = %s
+            """,
+            (
+                name,
+                company.address,
+                company.address2,
+                company.zip,
+                company.city,
+                company.country,
+                company.phone,
+                company.www,
+                company_id,
+            ),
+        )
+        return company_id
+
+    if not name:
+        return None
+
+    cursor.execute(
+        """
+        INSERT INTO companies
+            (name, orgnr, address, address2, zip, city, country, phone, www)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+        """,
+        (
+            name,
+            orgnr,
+            company.address,
+            company.address2,
+            company.zip,
+            company.city,
+            company.country,
+            company.phone,
+            company.www,
+        ),
+    )
+    return int(cursor.lastrowid)
+
+
+def _replace_receipt_items(cursor, file_id: str, items: Iterable[ReceiptItem]) -> None:
+    cursor.execute("DELETE FROM receipt_items WHERE main_id = %s", (file_id,))
+    for item in items:
+        cursor.execute(
+            """
+            INSERT INTO receipt_items (
+                main_id, article_id, name, number,
+                item_price_ex_vat, item_price_inc_vat,
+                item_total_price_ex_vat, item_total_price_inc_vat,
+                currency, vat, vat_percentage
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            """,
+            (
+                file_id,
+                item.article_id,
+                item.name,
+                item.number,
+                item.item_price_ex_vat,
+                item.item_price_inc_vat,
+                item.item_total_price_ex_vat,
+                item.item_total_price_inc_vat,
+                item.currency,
+                item.vat,
+                item.vat_percentage,
+            ),
         )
 
-        return jsonify(response.dict()), 200
 
-    except Exception as e:
-        logger.error(f"Error in document classification: {str(e)}")
-        return jsonify({"error": str(e)}), 500
-
-
-@bp.route('/classify/expense', methods=['POST'])
-@auth_required
-def classify_expense():
-    """
-    AI2 - Expense Type Classification
-    Determines if expense is personal or corporate.
-    """
+def _persist_extraction_result(
+    file_id: str,
+    result: DataExtractionResponse,
+    *,
+    connection=None,
+) -> None:
+    owns_connection = connection is None
+    conn = connection or get_connection()
+    cursor = conn.cursor()
     try:
-        data = request.get_json()
-        req = ExpenseClassificationRequest(**data)
-
-        # Call AI service for expense classification
-        ai_service = AIService()
-        result = ai_service.classify_expense(req)
-
-        # Update database
-        with db_cursor() as cursor:
-            cursor.execute(
-                """
-                UPDATE unified_files
-                SET expense_type = %s,
-                    ai_confidence = GREATEST(IFNULL(ai_confidence, 0), %s),
-                    updated_at = NOW()
-                WHERE id = %s
-                """,
-                (result.expense_type, result.confidence, req.file_id),
-            )
-
-        response = ExpenseClassificationResponse(
-            file_id=req.file_id,
-            expense_type=result.expense_type,
-            confidence=result.confidence,
-            card_identifier=result.card_identifier,
-            reasoning=result.reasoning,
+        if owns_connection:
+            conn.start_transaction()
+        company_id = _ensure_company(cursor, result.company)
+        unified = result.unified_file
+        updates: Dict[str, Any] = {
+            "orgnr": unified.orgnr,
+            "payment_type": unified.payment_type or "cash",
+            "purchase_datetime": unified.purchase_datetime,
+            "expense_type": unified.expense_type or "personal",
+            "gross_amount_original": unified.gross_amount_original,
+            "net_amount_original": unified.net_amount_original,
+            "exchange_rate": unified.exchange_rate or Decimal("1"),
+            "currency": unified.currency or "SEK",
+            "gross_amount_sek": unified.gross_amount_sek,
+            "net_amount_sek": unified.net_amount_sek,
+            "company_id": company_id,
+            "receipt_number": unified.receipt_number,
+            "other_data": unified.other_data or "{}",
+            "ocr_raw": unified.ocr_raw or "",
+        }
+        set_parts: List[str] = []
+        params: List[Any] = []
+        for column, value in updates.items():
+            if value is None:
+                continue
+            set_parts.append(f"{column} = %s")
+            params.append(value)
+        set_parts.append("updated_at = NOW()")
+        params.append(file_id)
+        cursor.execute(
+            "UPDATE unified_files SET " + ", ".join(set_parts) + " WHERE id = %s",
+            tuple(params),
         )
-
-        return jsonify(response.dict()), 200
-
-    except Exception as e:
-        logger.error(f"Error in expense classification: {str(e)}")
-        return jsonify({"error": str(e)}), 500
-
-
-@bp.route('/extract', methods=['POST'])
-@auth_required
-def extract_data():
-    """
-    AI3 - Data Extraction
-    Extracts structured data from receipt/invoice to database.
-    """
-    try:
-        data = request.get_json()
-        req = DataExtractionRequest(**data)
-
-        ai_service = AIService()
-        result = ai_service.extract_data(req)
-
-        _persist_extraction_result(req.file_id, result)
-
-        response = DataExtractionResponse(
-            file_id=req.file_id,
-            unified_file=result.unified_file,
-            receipt_items=result.receipt_items,
-            company=result.company,
-            confidence=result.confidence
-        )
-
-        return jsonify(response.dict()), 200
-
-    except Exception as e:
-        logger.error(f"Error in data extraction: {str(e)}")
-        return jsonify({"error": str(e)}), 500
-
-
-@bp.route('/classify/accounting', methods=['POST'])
-@auth_required
-def classify_accounting():
-    """
-    AI4 - Accounting Classification
-    Classifies and assigns accounts according to BAS-2025.
-    """
-    try:
-        data = request.get_json()
-        req = AccountingClassificationRequest(**data)
-
-        # Get BAS-2025 chart of accounts from database
-        with db_cursor() as cursor:
-            cursor.execute(
-                """
-                SELECT sub_account, sub_account_description
-                FROM chart_of_accounts
-                WHERE sub_account IS NOT NULL AND sub_account <> ''
-                """
-            )
-            chart_of_accounts = cursor.fetchall()
-
-        # Call AI service for accounting classification
-        ai_service = AIService()
-        result = ai_service.classify_accounting(req, chart_of_accounts)
-
-        # Store AI accounting proposals
-        with closing(get_connection()) as conn:
-            cursor = conn.cursor()
-
-            # Delete existing proposals for this receipt
-            cursor.execute(
-                "DELETE FROM ai_accounting_proposals WHERE receipt_id = %s",
-                (req.file_id,),
-            )
-
-            # Insert new proposals
-            for proposal in result.proposals:
-                cursor.execute(
-                    """
-                    INSERT INTO ai_accounting_proposals (
-                        receipt_id, account_code, debit, credit, vat_rate, notes
-                    ) VALUES (%s, %s, %s, %s, %s, %s)
-                    """,
-                    (
-                        proposal.receipt_id,
-                        proposal.account_code,
-                        proposal.debit,
-                        proposal.credit,
-                        proposal.vat_rate,
-                        proposal.notes,
-                    ),
-                )
-
+        if cursor.rowcount == 0:
+            raise ValueError(f"File {file_id} not found")
+        _replace_receipt_items(cursor, file_id, result.receipt_items)
+        _set_ai_stage(cursor, file_id, "AI3", result.confidence)
+        if owns_connection:
             conn.commit()
-
-        response = AccountingClassificationResponse(
-            file_id=req.file_id,
-            proposals=result.proposals,
-            confidence=result.confidence,
-            based_on_bas2025=True
-        )
-
-        return jsonify(response.dict()), 200
-
-    except Exception as e:
-        logger.error(f"Error in accounting classification: {str(e)}")
-        return jsonify({"error": str(e)}), 500
-
-
-@bp.route('/match/creditcard', methods=['POST'])
-@auth_required
-def match_credit_card():
-    """
-    AI5 - Credit Card Invoice Matching
-    Matches receipts with credit card invoice line items.
-    """
-    try:
-        data = request.get_json()
-        req = CreditCardMatchRequest(**data)
-
-        purchase_date = req.purchase_date.date() if isinstance(req.purchase_date, datetime) else req.purchase_date
-
-        with db_cursor() as cursor:
-            cursor.execute(
-                """
-                SELECT i.id, i.merchant_name, i.amount_sek
-                FROM creditcard_invoice_items AS i
-                LEFT JOIN creditcard_receipt_matches AS m ON m.invoice_item_id = i.id
-                WHERE i.purchase_date = %s
-                  AND m.invoice_item_id IS NULL
-                  AND (%s IS NULL OR i.amount_sek IS NULL OR ABS(i.amount_sek - %s) <= 5)
-                ORDER BY ABS(IFNULL(i.amount_sek, %s) - %s)
-                LIMIT 25
-                """,
-                (purchase_date, req.amount, req.amount, req.amount, req.amount),
-            )
-            potential_matches = cursor.fetchall()
-
-        # Call AI service for intelligent matching
-        ai_service = AIService()
-        result = ai_service.match_credit_card(req, potential_matches)
-
-        if result.matched and result.credit_card_invoice_item_id:
-            _persist_credit_card_match(
-                req.file_id,
-                result.credit_card_invoice_item_id,
-                req.amount,
-            )
-
-        response = CreditCardMatchResponse(
-            file_id=req.file_id,
-            matched=result.matched,
-            credit_card_invoice_item_id=result.credit_card_invoice_item_id,
-            confidence=result.confidence,
-            match_details=result.match_details
-        )
-
-        return jsonify(response.dict()), 200
-
-    except Exception as e:
-        logger.error(f"Error in credit card matching: {str(e)}")
-        return jsonify({"error": str(e)}), 500
-
-
-def _persist_extraction_result(file_id: str, result: DataExtractionResponse) -> None:
-    """Persist the extraction response into unified_files, companies and receipt_items."""
-
-    unified = result.unified_file
-    company = result.company
-
-    with closing(get_connection()) as conn:
-        conn.start_transaction()
-        cursor = conn.cursor()
-        try:
-            company_id: Optional[int] = None
-            orgnr = (company.orgnr or "").strip() or None
-            name = (company.name or "").strip() or None
-
-            if orgnr:
-                cursor.execute("SELECT id FROM companies WHERE orgnr = %s", (orgnr,))
-                existing = cursor.fetchone()
-                if existing:
-                    company_id = existing[0]
-                    cursor.execute(
-                        """
-                        UPDATE companies
-                        SET name = COALESCE(%s, name),
-                            address = COALESCE(%s, address),
-                            address2 = COALESCE(%s, address2),
-                            zip = COALESCE(%s, zip),
-                            city = COALESCE(%s, city),
-                            country = COALESCE(%s, country),
-                            phone = COALESCE(%s, phone),
-                            www = COALESCE(%s, www),
-                            updated_at = NOW()
-                        WHERE id = %s
-                        """,
-                        (
-                            name,
-                            company.address,
-                            company.address2,
-                            company.zip,
-                            company.city,
-                            company.country,
-                            company.phone,
-                            company.www,
-                            company_id,
-                        ),
-                    )
-                elif name:
-                    cursor.execute(
-                        """
-                        INSERT INTO companies (name, orgnr, address, address2, zip, city, country, phone, www)
-                        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
-                        """,
-                        (
-                            name,
-                            orgnr,
-                            company.address,
-                            company.address2,
-                            company.zip,
-                            company.city,
-                            company.country,
-                            company.phone,
-                            company.www,
-                        ),
-                    )
-                    company_id = cursor.lastrowid
-            elif name:
-                logger.info("Company orgnr missing for %s – skipping company insert", file_id)
-
-            updates = {
-                "orgnr": unified.orgnr,
-                "payment_type": unified.payment_type,
-                "purchase_datetime": unified.purchase_datetime,
-                "expense_type": unified.expense_type,
-                "gross_amount_original": unified.gross_amount_original,
-                "net_amount_original": unified.net_amount_original,
-                "exchange_rate": unified.exchange_rate,
-                "currency": unified.currency,
-                "gross_amount_sek": unified.gross_amount_sek,
-                "net_amount_sek": unified.net_amount_sek,
-                "company_id": company_id,
-                "receipt_number": unified.receipt_number,
-                "other_data": unified.other_data,
-                "ocr_raw": unified.ocr_raw or "",
-                "ai_status": 'completed',
-                "ai_confidence": result.confidence,
-            }
-
-            set_parts: List[str] = []
-            params: List[Any] = []
-            for column, value in updates.items():
-                set_parts.append(f"{column} = %s")
-                params.append(value)
-            set_parts.append("updated_at = NOW()")
-            params.append(file_id)
-
-            cursor.execute(
-                "UPDATE unified_files SET " + ", ".join(set_parts) + " WHERE id = %s",
-                tuple(params),
-            )
-
-            cursor.execute("DELETE FROM receipt_items WHERE main_id = %s", (file_id,))
-            for item in result.receipt_items:
-                cursor.execute(
-                    """
-                    INSERT INTO receipt_items (
-                        main_id, article_id, name, number,
-                        item_price_ex_vat, item_price_inc_vat,
-                        item_total_price_ex_vat, item_total_price_inc_vat,
-                        currency, vat, vat_percentage
-                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-                    """,
-                    (
-                        file_id,
-                        item.article_id,
-                        item.name,
-                        item.number,
-                        item.item_price_ex_vat,
-                        item.item_price_inc_vat,
-                        item.item_total_price_ex_vat,
-                        item.item_total_price_inc_vat,
-                        item.currency,
-                        item.vat,
-                        item.vat_percentage,
-                    ),
-                )
-
-            conn.commit()
-        except Exception:
+    except Exception:
+        if owns_connection:
             conn.rollback()
-            raise
-        finally:
-            cursor.close()
+        raise
+    finally:
+        cursor.close()
+        if owns_connection:
+            conn.close()
+
+
+def _persist_accounting_proposals(
+    file_id: str,
+    proposals: Iterable[AccountingProposal],
+    confidence: float,
+    *,
+    connection=None,
+) -> None:
+    owns_connection = connection is None
+    conn = connection or get_connection()
+    cursor = conn.cursor()
+    try:
+        if owns_connection:
+            conn.start_transaction()
+        cursor.execute("DELETE FROM ai_accounting_proposals WHERE receipt_id = %s", (file_id,))
+        for proposal in proposals:
+            cursor.execute(
+                """
+                INSERT INTO ai_accounting_proposals (
+                    receipt_id, account_code, debit, credit, vat_rate, notes
+                ) VALUES (%s, %s, %s, %s, %s, %s)
+                """,
+                (
+                    proposal.receipt_id,
+                    proposal.account_code,
+                    proposal.debit,
+                    proposal.credit,
+                    proposal.vat_rate,
+                    proposal.notes,
+                ),
+            )
+        _set_ai_stage(cursor, file_id, "AI4", confidence)
+        if owns_connection:
+            conn.commit()
+    except Exception:
+        if owns_connection:
+            conn.rollback()
+        raise
+    finally:
+        cursor.close()
+        if owns_connection:
+            conn.close()
 
 
 def _persist_credit_card_match(
     file_id: str,
-    invoice_item_id: int,
+    invoice_item_id: Optional[int],
     matched_amount: Optional[Decimal],
+    confidence: Optional[float],
+    matched: bool,
+    *,
+    connection=None,
 ) -> None:
-    """Persist the credit card match relation and update unified_files."""
-
-    with closing(get_connection()) as conn:
-        conn.start_transaction()
-        cursor = conn.cursor()
-        try:
+    owns_connection = connection is None
+    conn = connection or get_connection()
+    cursor = conn.cursor()
+    try:
+        if owns_connection:
+            conn.start_transaction()
+        if matched and invoice_item_id is not None:
             cursor.execute(
                 """
                 INSERT INTO creditcard_receipt_matches (receipt_id, invoice_item_id, matched_amount)
@@ -426,286 +312,87 @@ def _persist_credit_card_match(
                 """,
                 (file_id, invoice_item_id, matched_amount),
             )
-            cursor.execute(
-                "UPDATE unified_files SET credit_card_match = 1, updated_at = NOW() WHERE id = %s",
-                (file_id,),
-            )
-            conn.commit()
-        except Exception:
-            conn.rollback()
-            raise
-        finally:
-            cursor.close()
-
-
-@bp.route('/process/batch', methods=['POST'])
-@auth_required
-def process_batch():
-    """
-    Batch processing of multiple files through AI pipeline.
-    """
-    try:
-        data = request.get_json()
-        req = BatchProcessingRequest(**data)
-
-        results = []
-        processed = 0
-        failed = 0
-
-        for file_id in req.file_ids:
-            try:
-                file_result = {"file_id": file_id, "steps_completed": []}
-
-                # Get file info
-                with db_cursor() as cursor:
-                    cursor.execute(
-                        """
-                        SELECT ocr_raw, file_type, expense_type
-                        FROM unified_files WHERE id = %s
-                        """,
-                        (file_id,),
-                    )
-                    file_info = cursor.fetchone()
-
-                if not file_info:
-                    raise ValueError(f"File {file_id} not found")
-
-                ocr_text, doc_type, expense_type = file_info
-
-                # Process through requested steps
-                for step in req.processing_steps:
-                    if step == "AI1" and doc_type is None:
-                        # Document classification
-                        classify_req = DocumentClassificationRequest(
-                            file_id=file_id, ocr_text=ocr_text
-                        )
-                        classify_document_internal(classify_req)
-                        file_result["steps_completed"].append("AI1")
-
-                    elif step == "AI2" and expense_type is None:
-                        # Expense classification
-                        expense_req = ExpenseClassificationRequest(
-                            file_id=file_id, ocr_text=ocr_text, document_type=doc_type
-                        )
-                        classify_expense_internal(expense_req)
-                        file_result["steps_completed"].append("AI2")
-
-                    elif step == "AI3":
-                        # Data extraction
-                        extract_req = DataExtractionRequest(
-                            file_id=file_id, ocr_text=ocr_text,
-                            document_type=doc_type, expense_type=expense_type
-                        )
-                        extract_data_internal(extract_req)
-                        file_result["steps_completed"].append("AI3")
-
-                    elif step == "AI4":
-                        # Accounting classification
-                        # Get amounts from database
-                        with db_cursor() as cursor:
-                            cursor.execute(
-                                """
-                                SELECT gross_amount_sek, net_amount_sek,
-                                       (gross_amount_sek - net_amount_sek) AS vat_amount,
-                                       c.name AS vendor_name
-                                FROM unified_files uf
-                                LEFT JOIN companies c ON uf.company_id = c.id
-                                WHERE uf.id = %s
-                                """,
-                                (file_id,),
-                            )
-                            amounts = cursor.fetchone()
-
-                        if amounts:
-                            account_req = AccountingClassificationRequest(
-                                file_id=file_id,
-                                document_type=doc_type,
-                                expense_type=expense_type,
-                                gross_amount=amounts[0],
-                                net_amount=amounts[1],
-                                vat_amount=amounts[2],
-                                vendor_name=amounts[3],
-                                receipt_items=[]
-                            )
-                            classify_accounting_internal(account_req)
-                            file_result["steps_completed"].append("AI4")
-
-                    elif step == "AI5":
-                        # Credit card matching
-                        with db_cursor() as cursor:
-                            cursor.execute(
-                                """
-                                SELECT purchase_datetime, gross_amount_sek, c.name
-                                FROM unified_files uf
-                                LEFT JOIN companies c ON uf.company_id = c.id
-                                WHERE uf.id = %s
-                                """,
-                                (file_id,),
-                            )
-                            match_info = cursor.fetchone()
-
-                        if match_info and match_info[0]:
-                            match_req = CreditCardMatchRequest(
-                                file_id=file_id,
-                                purchase_date=match_info[0],
-                                amount=match_info[1],
-                                merchant_name=match_info[2]
-                            )
-                            match_credit_card_internal(match_req)
-                            file_result["steps_completed"].append("AI5")
-
-                results.append(file_result)
-                processed += 1
-
-            except Exception as e:
-                failed += 1
-                results.append({
-                    "file_id": file_id,
-                    "error": str(e),
-                    "steps_completed": file_result.get("steps_completed", [])
-                })
-
-                if req.stop_on_error:
-                    break
-
-        response = BatchProcessingResponse(
-            total_files=len(req.file_ids),
-            processed=processed,
-            failed=failed,
-            results=results
+        cursor.execute(
+            "UPDATE unified_files SET credit_card_match = %s, updated_at = NOW() WHERE id = %s",
+            (1 if matched else 0, file_id),
         )
+        _set_ai_stage(cursor, file_id, "AI5", confidence, matched=matched)
+        if owns_connection:
+            conn.commit()
+    except Exception:
+        if owns_connection:
+            conn.rollback()
+        raise
+    finally:
+        cursor.close()
+        if owns_connection:
+            conn.close()
 
-        return jsonify(response.dict()), 200
 
-    except Exception as e:
-        logger.error(f"Error in batch processing: {str(e)}")
-        return jsonify({"error": str(e)}), 500
-
-
-@bp.route('/status/<file_id>', methods=['GET'])
-@auth_required
-def get_ai_status(file_id: str):
-    """Get AI processing status for a specific file."""
+def _mark_manual_review(file_id: str, reason: Optional[str] = None) -> None:
     try:
         with db_cursor() as cursor:
             cursor.execute(
-                """
-                SELECT id, ai_status, ai_confidence, file_type, expense_type,
-                       credit_card_match, updated_at
-                FROM unified_files
-                WHERE id = %s
-                """,
+                "UPDATE unified_files SET ai_status = 'manual_review', updated_at = NOW() WHERE id = %s",
                 (file_id,),
             )
-
-            result = cursor.fetchone()
-
-            if not result:
-                return jsonify({"error": "File not found"}), 404
-
-            status = {
-                "file_id": result[0],
-                "ai_status": result[1],
-                "ai_confidence": result[2],
-                "document_type": result[3],
-                "expense_type": result[4],
-                "credit_card_matched": bool(result[5]),
-                "last_updated": result[6].isoformat() if result[6] else None
-            }
-
-            # Check for accounting proposals
-            cursor.execute(
-                """
-                SELECT COUNT(*) FROM ai_accounting_proposals WHERE receipt_id = %s
-                """,
-                (file_id,),
-            )
-            proposal_count = cursor.fetchone()[0]
-            status["has_accounting_proposals"] = proposal_count > 0
-
-            return jsonify(status), 200
-
-    except Exception as e:
-        logger.error(f"Error getting AI status: {str(e)}")
-        return jsonify({"error": str(e)}), 500
+    except Exception as exc:  # pragma: no cover - best effort logging only
+        logger.warning("Failed to mark %s for manual review: %s", file_id, exc)
+    if reason:
+        logger.warning("Manual review for %s: %s", file_id, reason)
 
 
-# Internal helper functions for batch processing
-def classify_document_internal(req: DocumentClassificationRequest):
-    """Internal function for document classification."""
-    ai_service = AIService()
-    result = ai_service.classify_document(req)
+# ---------------------------------------------------------------------------
+# Internal loaders
+# ---------------------------------------------------------------------------
 
-    with db_cursor() as cursor:
-        cursor.execute(
-            """
-            UPDATE unified_files
-            SET file_type = %s, ai_confidence = %s, updated_at = NOW()
-            WHERE id = %s
-            """,
-            (result.document_type, result.confidence, req.file_id),
-        )
-
-    return result
-
-
-def classify_expense_internal(req: ExpenseClassificationRequest):
-    """Internal function for expense classification."""
-    ai_service = AIService()
-    result = ai_service.classify_expense(req)
-
-    with db_cursor() as cursor:
-        cursor.execute(
-            """
-            UPDATE unified_files
-            SET expense_type = %s, updated_at = NOW()
-            WHERE id = %s
-            """,
-            (result.expense_type, req.file_id),
-        )
-
-    return result
-
-
-def extract_data_internal(req: DataExtractionRequest):
-    """Internal function for data extraction."""
-    ai_service = AIService()
-    result = ai_service.extract_data(req)
-    _persist_extraction_result(req.file_id, result)
-    return result
-
-
-def classify_accounting_internal(req: AccountingClassificationRequest):
-    """Internal function for accounting classification."""
+def _load_chart_of_accounts() -> List[Tuple[Any, ...]]:
     with db_cursor() as cursor:
         cursor.execute(
             """
             SELECT sub_account, sub_account_description
-            FROM chart_of_accounts
-            WHERE sub_account IS NOT NULL AND sub_account <> ''
+              FROM chart_of_accounts
+             WHERE sub_account IS NOT NULL AND sub_account <> ''
             """
         )
-        chart_of_accounts = cursor.fetchall()
-
-    ai_service = AIService()
-    result = ai_service.classify_accounting(req, chart_of_accounts)
-    # Implementation same as classify_accounting endpoint
-    return result
+        return cursor.fetchall()
 
 
-def match_credit_card_internal(req: CreditCardMatchRequest):
-    """Internal function for credit card matching."""
+def _load_unified_file(file_id: str) -> Optional[Tuple[str, Optional[str], Optional[str]]]:
+    with db_cursor() as cursor:
+        cursor.execute(
+            "SELECT ocr_raw, file_type, expense_type FROM unified_files WHERE id = %s",
+            (file_id,),
+        )
+        return cursor.fetchone()
+
+
+def _load_match_context(file_id: str) -> Optional[Tuple[datetime, Optional[Decimal], Optional[str]]]:
+    with db_cursor() as cursor:
+        cursor.execute(
+            """
+            SELECT purchase_datetime, gross_amount_sek, c.name
+              FROM unified_files uf
+         LEFT JOIN companies c ON uf.company_id = c.id
+             WHERE uf.id = %s
+            """,
+            (file_id,),
+        )
+        return cursor.fetchone()
+
+
+def _potential_credit_matches(req: CreditCardMatchRequest) -> List[Tuple[Any, ...]]:
     with db_cursor() as cursor:
         cursor.execute(
             """
             SELECT i.id, i.merchant_name, i.amount_sek
-            FROM creditcard_invoice_items AS i
-            LEFT JOIN creditcard_receipt_matches AS m ON m.invoice_item_id = i.id
-            WHERE i.purchase_date = %s
-              AND m.invoice_item_id IS NULL
-              AND (%s IS NULL OR i.amount_sek IS NULL OR ABS(i.amount_sek - %s) <= 5)
-            ORDER BY ABS(IFNULL(i.amount_sek, %s) - %s)
-            LIMIT 25
+              FROM creditcard_invoice_items AS i
+         LEFT JOIN creditcard_receipt_matches AS m ON m.invoice_item_id = i.id
+             WHERE i.purchase_date = %s
+               AND m.invoice_item_id IS NULL
+               AND (%s IS NULL OR i.amount_sek IS NULL OR ABS(i.amount_sek - %s) <= 5)
+          ORDER BY ABS(IFNULL(i.amount_sek, %s) - %s)
+             LIMIT 25
             """,
             (
                 req.purchase_date.date() if isinstance(req.purchase_date, datetime) else req.purchase_date,
@@ -715,16 +402,320 @@ def match_credit_card_internal(req: CreditCardMatchRequest):
                 req.amount,
             ),
         )
-        potential_matches = cursor.fetchall()
+        return cursor.fetchall()
 
+
+# ---------------------------------------------------------------------------
+# Internal AI stage executors
+# ---------------------------------------------------------------------------
+
+def classify_document_internal(req: DocumentClassificationRequest) -> DocumentClassificationResponse:
+    ai_service = AIService()
+    result = ai_service.classify_document(req)
+    with closing(get_connection()) as conn:
+        conn.start_transaction()
+        cursor = conn.cursor()
+        try:
+            cursor.execute(
+                "UPDATE unified_files SET file_type = %s WHERE id = %s",
+                (result.document_type, req.file_id),
+            )
+            if cursor.rowcount == 0:
+                raise ValueError(f"File {req.file_id} not found")
+            _set_ai_stage(cursor, req.file_id, "AI1", result.confidence)
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            cursor.close()
+    return result
+
+
+def classify_expense_internal(req: ExpenseClassificationRequest) -> ExpenseClassificationResponse:
+    ai_service = AIService()
+    result = ai_service.classify_expense(req)
+    with closing(get_connection()) as conn:
+        conn.start_transaction()
+        cursor = conn.cursor()
+        try:
+            cursor.execute(
+                "UPDATE unified_files SET expense_type = %s WHERE id = %s",
+                (result.expense_type, req.file_id),
+            )
+            if cursor.rowcount == 0:
+                raise ValueError(f"File {req.file_id} not found")
+            _set_ai_stage(cursor, req.file_id, "AI2", result.confidence)
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            cursor.close()
+    return result
+
+
+def extract_data_internal(req: DataExtractionRequest) -> DataExtractionResponse:
+    ai_service = AIService()
+    result = ai_service.extract_data(req)
+    _persist_extraction_result(req.file_id, result)
+    return result
+
+
+def classify_accounting_internal(req: AccountingClassificationRequest) -> AccountingClassificationResponse:
+    chart_of_accounts = _load_chart_of_accounts()
+    ai_service = AIService()
+    result = ai_service.classify_accounting(req, chart_of_accounts)
+    _persist_accounting_proposals(req.file_id, result.proposals, result.confidence)
+    return result
+
+
+def match_credit_card_internal(req: CreditCardMatchRequest) -> CreditCardMatchResponse:
+    potential_matches = _potential_credit_matches(req)
     ai_service = AIService()
     result = ai_service.match_credit_card(req, potential_matches)
-
-    if result.matched and result.credit_card_invoice_item_id:
-        _persist_credit_card_match(
-            req.file_id,
-            result.credit_card_invoice_item_id,
-            req.amount,
-        )
-
+    matched_amount: Optional[Decimal] = None
+    if result.match_details and result.match_details.get("matched_amount") is not None:
+        matched_amount = Decimal(str(result.match_details["matched_amount"]))
+    _persist_credit_card_match(
+        req.file_id,
+        result.credit_card_invoice_item_id,
+        matched_amount,
+        result.confidence,
+        result.matched,
+    )
     return result
+
+
+# ---------------------------------------------------------------------------
+# Flask endpoints
+# ---------------------------------------------------------------------------
+
+@bp.route("/classify/document", methods=["POST"])
+@auth_required
+def classify_document() -> Any:
+    try:
+        payload = request.get_json(force=True) or {}
+        req = DocumentClassificationRequest(**payload)
+        result = classify_document_internal(req)
+        return jsonify(result.dict()), 200
+    except ValidationError as exc:
+        return jsonify({"error": exc.errors()}), 400
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 404
+    except Exception as exc:
+        logger.exception("Error in document classification")
+        _mark_manual_review(payload.get("file_id", ""), str(exc))
+        return jsonify({"error": "Document classification failed"}), 500
+
+
+@bp.route("/classify/expense", methods=["POST"])
+@auth_required
+def classify_expense() -> Any:
+    try:
+        payload = request.get_json(force=True) or {}
+        req = ExpenseClassificationRequest(**payload)
+        result = classify_expense_internal(req)
+        return jsonify(result.dict()), 200
+    except ValidationError as exc:
+        return jsonify({"error": exc.errors()}), 400
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 404
+    except Exception as exc:
+        logger.exception("Error in expense classification")
+        _mark_manual_review(payload.get("file_id", ""), str(exc))
+        return jsonify({"error": "Expense classification failed"}), 500
+
+
+@bp.route("/extract", methods=["POST"])
+@auth_required
+def extract_data() -> Any:
+    try:
+        payload = request.get_json(force=True) or {}
+        req = DataExtractionRequest(**payload)
+        result = extract_data_internal(req)
+        return jsonify(result.dict()), 200
+    except ValidationError as exc:
+        return jsonify({"error": exc.errors()}), 400
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 404
+    except Exception as exc:
+        logger.exception("Error in data extraction")
+        _mark_manual_review(payload.get("file_id", ""), str(exc))
+        return jsonify({"error": "Data extraction failed"}), 500
+
+
+@bp.route("/classify/accounting", methods=["POST"])
+@auth_required
+def classify_accounting() -> Any:
+    try:
+        payload = request.get_json(force=True) or {}
+        req = AccountingClassificationRequest(**payload)
+        result = classify_accounting_internal(req)
+        return jsonify(result.dict()), 200
+    except ValidationError as exc:
+        return jsonify({"error": exc.errors()}), 400
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 404
+    except Exception as exc:
+        logger.exception("Error in accounting classification")
+        _mark_manual_review(payload.get("file_id", ""), str(exc))
+        return jsonify({"error": "Accounting classification failed"}), 500
+
+
+@bp.route("/match/creditcard", methods=["POST"])
+@auth_required
+def match_credit_card() -> Any:
+    try:
+        payload = request.get_json(force=True) or {}
+        req = CreditCardMatchRequest(**payload)
+        result = match_credit_card_internal(req)
+        return jsonify(result.dict()), 200
+    except ValidationError as exc:
+        return jsonify({"error": exc.errors()}), 400
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 404
+    except Exception as exc:
+        logger.exception("Error in credit card matching")
+        _mark_manual_review(payload.get("file_id", ""), str(exc))
+        return jsonify({"error": "Credit card matching failed"}), 500
+
+
+@bp.route("/process/batch", methods=["POST"])
+@auth_required
+def process_batch() -> Any:
+    try:
+        payload = request.get_json(force=True) or {}
+        req = BatchProcessingRequest(**payload)
+        results: List[Dict[str, Any]] = []
+        processed = 0
+        failed = 0
+        for file_id in req.file_ids:
+            file_result: Dict[str, Any] = {"file_id": file_id, "steps_completed": []}
+            try:
+                for step in req.processing_steps:
+                    context = _load_unified_file(file_id)
+                    if context is None:
+                        raise ValueError(f"File {file_id} not found")
+                    ocr_text, document_type, expense_type = context
+                    if step == "AI1":
+                        classify_document_internal(
+                            DocumentClassificationRequest(file_id=file_id, ocr_text=ocr_text)
+                        )
+                        file_result["steps_completed"].append("AI1")
+                    elif step == "AI2":
+                        classify_expense_internal(
+                            ExpenseClassificationRequest(
+                                file_id=file_id,
+                                ocr_text=ocr_text,
+                                document_type=document_type or "other",
+                            )
+                        )
+                        file_result["steps_completed"].append("AI2")
+                    elif step == "AI3":
+                        extract_data_internal(
+                            DataExtractionRequest(
+                                file_id=file_id,
+                                ocr_text=ocr_text or "",
+                                document_type=document_type or "other",
+                                expense_type=expense_type or "personal",
+                            )
+                        )
+                        file_result["steps_completed"].append("AI3")
+                    elif step == "AI4":
+                        with db_cursor() as cursor:
+                            cursor.execute(
+                                """
+                                SELECT gross_amount_sek, net_amount_sek,
+                                       (gross_amount_sek - net_amount_sek) AS vat_amount,
+                                       c.name AS vendor_name
+                                  FROM unified_files uf
+                             LEFT JOIN companies c ON uf.company_id = c.id
+                                 WHERE uf.id = %s
+                                """,
+                                (file_id,),
+                            )
+                            amounts = cursor.fetchone()
+                        if amounts:
+                            classify_accounting_internal(
+                                AccountingClassificationRequest(
+                                    file_id=file_id,
+                                    document_type=document_type or "other",
+                                    expense_type=expense_type or "personal",
+                                    gross_amount=Decimal(str(amounts[0] or 0)),
+                                    net_amount=Decimal(str(amounts[1] or 0)),
+                                    vat_amount=Decimal(str(amounts[2] or 0)),
+                                    vendor_name=amounts[3] or "",
+                                    receipt_items=[],
+                                )
+                            )
+                            file_result["steps_completed"].append("AI4")
+                    elif step == "AI5":
+                        match_info = _load_match_context(file_id)
+                        if match_info and match_info[0]:
+                            match_credit_card_internal(
+                                CreditCardMatchRequest(
+                                    file_id=file_id,
+                                    purchase_date=match_info[0],
+                                    amount=match_info[1],
+                                    merchant_name=match_info[2],
+                                )
+                            )
+                            file_result["steps_completed"].append("AI5")
+                processed += 1
+                results.append(file_result)
+            except Exception as exc:
+                failed += 1
+                file_result["error"] = str(exc)
+                results.append(file_result)
+                if req.stop_on_error:
+                    break
+        response = BatchProcessingResponse(
+            total_files=len(req.file_ids),
+            processed=processed,
+            failed=failed,
+            results=results,
+        )
+        return jsonify(response.dict()), 200
+    except ValidationError as exc:
+        return jsonify({"error": exc.errors()}), 400
+    except Exception as exc:
+        logger.exception("Error in batch processing")
+        return jsonify({"error": str(exc)}), 500
+
+
+@bp.route("/status/<file_id>", methods=["GET"])
+@auth_required
+def get_ai_status(file_id: str):
+    try:
+        with db_cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT id, ai_status, ai_confidence, file_type, expense_type,
+                       credit_card_match, updated_at
+                  FROM unified_files
+                 WHERE id = %s
+                """,
+                (file_id,),
+            )
+            result = cursor.fetchone()
+            if not result:
+                return jsonify({"error": "File not found"}), 404
+            status = {
+                "file_id": result[0],
+                "ai_status": result[1],
+                "ai_confidence": result[2],
+                "document_type": result[3],
+                "expense_type": result[4],
+                "credit_card_matched": bool(result[5]),
+                "last_updated": result[6].isoformat() if result[6] else None,
+            }
+            cursor.execute(
+                "SELECT COUNT(*) FROM ai_accounting_proposals WHERE receipt_id = %s",
+                (file_id,),
+            )
+            status["has_accounting_proposals"] = cursor.fetchone()[0] > 0
+        return jsonify(status), 200
+    except Exception as exc:
+        logger.error("Error getting AI status: %s", exc)
+        return jsonify({"error": str(exc)}), 500

--- a/backend/tests/unit/test_ai_pipeline_persistence.py
+++ b/backend/tests/unit/test_ai_pipeline_persistence.py
@@ -1,0 +1,195 @@
+import sys
+from decimal import Decimal
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SRC = _REPO_ROOT / "backend" / "src"
+for candidate in (_REPO_ROOT, _SRC):
+    if str(candidate) not in sys.path:
+        sys.path.insert(0, str(candidate))
+
+import backend.src.api.ai_processing as ai_processing  # type: ignore
+from backend.src.models.ai_processing import (  # type: ignore
+    AccountingProposal,
+    Company,
+    DataExtractionResponse,
+    ReceiptItem,
+    UnifiedFileBase,
+)
+
+
+class FakeCursor:
+    def __init__(self, fetchone=None):
+        self.fetchone_queue = list(fetchone or [])
+        self.calls = []
+        self.lastrowid = 99
+        self.rowcount = 1
+
+    def execute(self, sql, params=None):
+        self.calls.append((" ".join(sql.split()), params))
+        if sql.strip().lower().startswith("update unified_files"):
+            self.rowcount = 1
+
+    def fetchone(self):
+        if self.fetchone_queue:
+            return self.fetchone_queue.pop(0)
+        return None
+
+    def fetchall(self):  # pragma: no cover - not needed here
+        return []
+
+    def close(self):
+        pass
+
+
+class FakeConnection:
+    def __init__(self, cursor):
+        self._cursor = cursor
+        self.started = False
+        self.committed = False
+        self.closed = False
+
+    def start_transaction(self):
+        self.started = True
+
+    def cursor(self):
+        return self._cursor
+
+    def commit(self):
+        self.committed = True
+
+    def rollback(self):  # pragma: no cover - not triggered in these tests
+        self.committed = False
+
+    def close(self):
+        self.closed = True
+
+
+def _build_extraction_response() -> DataExtractionResponse:
+    unified = UnifiedFileBase(
+        file_type="receipt",
+        orgnr="556677-8899",
+        payment_type="card",
+        purchase_datetime=None,
+        expense_type="corporate",
+        gross_amount_original=Decimal("123.45"),
+        net_amount_original=Decimal("98.76"),
+        exchange_rate=Decimal("1"),
+        currency="SEK",
+        gross_amount_sek=Decimal("123.45"),
+        net_amount_sek=Decimal("98.76"),
+        other_data="{}",
+        ocr_raw="Sample OCR text",
+        ai_status=None,
+        ai_confidence=None,
+        mime_type=None,
+        company_id=None,
+        receipt_number="ABC-123",
+        file_creation_timestamp=None,
+        submitted_by=None,
+        original_file_id=None,
+        original_file_name=None,
+        original_file_size=None,
+        file_suffix=None,
+        file_category=None,
+        original_filename=None,
+        approved_by=None,
+        credit_card_match=False,
+    )
+    company = Company(
+        name="Test Store",
+        orgnr="556677-8899",
+        address=None,
+        address2=None,
+        zip=None,
+        city=None,
+        country=None,
+        phone=None,
+        www=None,
+    )
+    items = [
+        ReceiptItem(
+            main_id="file-1",
+            article_id="SKU-1",
+            name="Coffee",
+            number=1,
+            item_price_ex_vat=Decimal("80.00"),
+            item_price_inc_vat=Decimal("100.00"),
+            item_total_price_ex_vat=Decimal("80.00"),
+            item_total_price_inc_vat=Decimal("100.00"),
+            currency="SEK",
+            vat=Decimal("20.00"),
+            vat_percentage=Decimal("25"),
+        )
+    ]
+    return DataExtractionResponse(
+        file_id="file-1",
+        unified_file=unified,
+        receipt_items=items,
+        company=company,
+        confidence=0.85,
+    )
+
+
+def test_persist_extraction_result_writes_company_and_receipts(monkeypatch):
+    fake_cursor = FakeCursor(fetchone=[None, None])
+    fake_conn = FakeConnection(fake_cursor)
+    monkeypatch.setattr(ai_processing, "get_connection", lambda: fake_conn)
+
+    result = _build_extraction_response()
+    ai_processing._persist_extraction_result("file-1", result)
+
+    sql_statements = "\n".join(call[0] for call in fake_cursor.calls)
+    assert "INSERT INTO companies" in sql_statements
+    assert "DELETE FROM receipt_items" in sql_statements
+    assert "INSERT INTO receipt_items" in sql_statements
+    assert "UPDATE unified_files SET" in sql_statements
+    assert fake_conn.committed is True
+
+
+def test_persist_credit_card_match_updates_status(monkeypatch):
+    fake_cursor = FakeCursor()
+    fake_conn = FakeConnection(fake_cursor)
+    monkeypatch.setattr(ai_processing, "get_connection", lambda: fake_conn)
+
+    ai_processing._persist_credit_card_match(
+        file_id="file-99",
+        invoice_item_id=123,
+        matched_amount=Decimal("199.00"),
+        confidence=0.92,
+        matched=True,
+    )
+
+    sql_statements = "\n".join(call[0] for call in fake_cursor.calls)
+    assert "INSERT INTO creditcard_receipt_matches" in sql_statements
+    assert sql_statements.count("UPDATE unified_files SET") >= 2  # stage + credit flag
+    assert fake_conn.committed is True
+
+
+def test_persist_accounting_proposals_replaces_rows(monkeypatch):
+    fake_cursor = FakeCursor()
+    fake_conn = FakeConnection(fake_cursor)
+    monkeypatch.setattr(ai_processing, "get_connection", lambda: fake_conn)
+
+    proposals = [
+        AccountingProposal(
+            receipt_id="file-77",
+            account_code="2440",
+            debit=Decimal("100"),
+            credit=Decimal("0"),
+            vat_rate=None,
+            notes="Test",
+        )
+    ]
+
+    ai_processing._persist_accounting_proposals(
+        file_id="file-77",
+        proposals=proposals,
+        confidence=0.75,
+    )
+
+    sql_statements = "\n".join(call[0] for call in fake_cursor.calls)
+    assert "DELETE FROM ai_accounting_proposals" in sql_statements
+    assert "INSERT INTO ai_accounting_proposals" in sql_statements
+    assert "UPDATE unified_files SET ai_status" in sql_statements
+    assert fake_conn.committed is True

--- a/docs/SYSTEM_DOCS/AI_PIPELINE_ENV.md
+++ b/docs/SYSTEM_DOCS/AI_PIPELINE_ENV.md
@@ -1,0 +1,26 @@
+# AI Pipeline Environment Configuration
+
+The AI processing pipeline relies on the same database settings across local
+workstations, CI, and production. Configure the following variables before
+starting the API or Celery worker:
+
+| Variable  | Description | Default |
+| --------- | ----------- | ------- |
+| `DB_HOST` | Hostname/IP of the MySQL server. | `127.0.0.1` |
+| `DB_PORT` | MySQL TCP port. | `3310` |
+| `DB_NAME` | Database containing `unified_files` and related tables. | `mono_se_db_9` |
+| `DB_USER` | MySQL user with read/write permissions. | `mind` |
+| `DB_PASS` | Password for `DB_USER`. | `mind` |
+
+Additional runtime settings used by the AI service:
+
+| Variable | Description | Default |
+| -------- | ----------- | ------- |
+| `AI_PROVIDER` | Optional LLM provider (`openai`, `azure_openai`). | unset |
+| `OPENAI_API_KEY` | API key when `AI_PROVIDER=openai`. | unset |
+| `AZURE_OPENAI_API_KEY` | API key when `AI_PROVIDER=azure_openai`. | unset |
+| `AZURE_OPENAI_ENDPOINT` | Endpoint URL for Azure OpenAI deployments. | unset |
+| `AI_MODEL_NAME` | Overrides the active model selected from DB tables. | unset |
+
+If provider-specific variables are missing, the AI service automatically falls
+back to deterministic rule-based parsing while logging the degraded mode.


### PR DESCRIPTION
## Summary
- add an idempotent SQL migration that aligns unified_files and dependent tables for the AI pipeline
- rebuild the ai_processing API helpers and endpoints to persist each AI stage transactionally and document required environment variables
- extend the AI service with provider adapters, update Celery to orchestrate AI1–AI5, and add unit tests for persistence helpers

## Testing
- pytest backend/tests/unit/test_ai_pipeline_persistence.py

------
https://chatgpt.com/codex/tasks/task_e_68db883a2d108324adddea11087b7430