### PR TITLE
Add receipt modal support across backend and frontend

### DIFF
--- a/backend/src/api/receipts.py
+++ b/backend/src/api/receipts.py
@@ -250,7 +250,7 @@ def _fetch_receipt_items(rid: str) -> list[dict[str, Any]]:
                         "id": int(item_id) if item_id is not None else None,
                         "article_id": article_id or "",
                         "name": name or "",
-                        "number": int(number) if number not in (None, "") else 0,
+                        "number": int(number) if number not in (None, "") else None,
                         "item_price_ex_vat": float(price_ex_vat) if price_ex_vat is not None else None,
                         "item_price_inc_vat": float(price_inc_vat) if price_inc_vat is not None else None,
                         "item_total_price_ex_vat": float(total_ex_vat) if total_ex_vat is not None else None,

--- a/backend/tests/unit/test_receipt_modal_api.py
+++ b/backend/tests/unit/test_receipt_modal_api.py
@@ -1,0 +1,292 @@
+import json
+import sys
+from datetime import datetime
+from decimal import Decimal
+from pathlib import Path
+
+
+class StubCursor:
+    def __init__(self, state, executed):
+        self.state = state
+        self.executed = executed
+        self._result = []
+        self.rowcount = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def execute(self, sql, params=None):
+        self.executed.append((sql, params))
+        params = params or ()
+        sql_clean = sql.strip()
+        sql_upper = sql_clean.upper()
+        if sql_upper.startswith("DELETE FROM RECEIPT_ITEMS"):
+            self.state["items"].clear()
+            self.rowcount = 1
+            self._result = []
+        elif sql_upper.startswith("INSERT INTO RECEIPT_ITEMS"):
+            values = list(params)
+            next_id = self.state.setdefault("next_item_id", 2)
+            self.state["items"].append(
+                {
+                    "id": next_id,
+                    "article_id": values[1],
+                    "name": values[2],
+                    "number": values[3],
+                    "item_price_ex_vat": values[4],
+                    "item_price_inc_vat": values[5],
+                    "item_total_price_ex_vat": values[6],
+                    "item_total_price_inc_vat": values[7],
+                    "currency": values[8],
+                    "vat": values[9],
+                    "vat_percentage": values[10],
+                }
+            )
+            self.state["next_item_id"] = next_id + 1
+            self.rowcount = 1
+            self._result = []
+        elif sql_upper.startswith("DELETE FROM AI_ACCOUNTING_PROPOSALS"):
+            self.state["proposals"].clear()
+            self.rowcount = 1
+            self._result = []
+        elif sql_upper.startswith("INSERT INTO AI_ACCOUNTING_PROPOSALS"):
+            values = list(params)
+            next_id = self.state.setdefault("next_proposal_id", 2)
+            self.state["proposals"].append(
+                {
+                    "id": next_id,
+                    "account_code": values[1],
+                    "debit": Decimal(str(values[2])),
+                    "credit": Decimal(str(values[3])),
+                    "vat_rate": Decimal(str(values[4])) if values[4] is not None else None,
+                    "notes": values[5],
+                }
+            )
+            self.state["next_proposal_id"] = next_id + 1
+            self.rowcount = 1
+            self._result = []
+        elif "FROM unified_files" in sql and "receipt_items" not in sql:
+            u = self.state["unified"]
+            self._result = [
+                (
+                    u["id"],
+                    u["merchant_name"],
+                    u["orgnr"],
+                    u["purchase_datetime"],
+                    u["gross_amount"],
+                    u["net_amount"],
+                    u["ai_status"],
+                    u["ai_confidence"],
+                    u["expense_type"],
+                    u["tags"],
+                    u["ocr_raw"],
+                )
+            ]
+        elif "FROM receipt_items" in sql:
+            items = []
+            for item in self.state["items"]:
+                items.append(
+                    (
+                        item["id"],
+                        item["article_id"],
+                        item["name"],
+                        item["number"],
+                        item["item_price_ex_vat"],
+                        item["item_price_inc_vat"],
+                        item["item_total_price_ex_vat"],
+                        item["item_total_price_inc_vat"],
+                        item["currency"],
+                        item["vat"],
+                        item["vat_percentage"],
+                    )
+                )
+            self._result = items
+        elif "FROM ai_accounting_proposals" in sql:
+            proposals = []
+            for entry in self.state["proposals"]:
+                proposals.append(
+                    (
+                        entry["id"],
+                        entry["account_code"],
+                        entry["debit"],
+                        entry["credit"],
+                        entry["vat_rate"],
+                        entry["notes"],
+                    )
+                )
+            self._result = proposals
+        elif sql_upper.startswith("UPDATE UNIFIED_FILES SET"):
+            assignments = sql.split("SET", 1)[1].split("WHERE")[0]
+            assignments = assignments.replace(", updated_at=NOW()", "")
+            columns = [part.split("=")[0].strip() for part in assignments.split(",") if "%s" in part]
+            values = list(params[:-1])  # Last param is receipt id
+            for column, value in zip(columns, values):
+                if column == "merchant_name":
+                    self.state["unified"]["merchant_name"] = value
+                elif column == "orgnr":
+                    self.state["unified"]["orgnr"] = value
+                elif column == "purchase_datetime":
+                    self.state["unified"]["purchase_datetime"] = value
+                elif column == "gross_amount":
+                    self.state["unified"]["gross_amount"] = Decimal(str(value))
+                elif column == "net_amount":
+                    self.state["unified"]["net_amount"] = Decimal(str(value))
+                elif column == "ai_status":
+                    self.state["unified"]["ai_status"] = value
+                elif column == "expense_type":
+                    self.state["unified"]["expense_type"] = value
+            self.rowcount = 1
+            self._result = []
+        else:
+            self._result = []
+
+    def fetchone(self):
+        return self._result[0] if self._result else None
+
+    def fetchall(self):
+        return list(self._result)
+
+
+def prepare_app(monkeypatch, tmp_path, state, executed):
+    monkeypatch.setenv("STORAGE_DIR", str(tmp_path))
+    monkeypatch.setenv("DB_AUTO_MIGRATE", "0")
+    root = Path(__file__).resolve().parents[2]
+    src = root / "src"
+    if str(src) not in sys.path:
+        sys.path.insert(0, str(src))
+
+    for module in ["api.app", "api.receipts"]:
+        if module in sys.modules:
+            sys.modules.pop(module)
+
+    from importlib import import_module
+
+    receipts_module = import_module("api.receipts")
+    monkeypatch.setattr(receipts_module, "db_cursor", lambda: StubCursor(state, executed))
+
+    app_module = import_module("api.app")
+    return app_module.app
+
+
+def build_initial_state(rid: str):
+    return {
+        "unified": {
+            "id": rid,
+            "merchant_name": "Merchant AB",
+            "orgnr": "556677-8899",
+            "purchase_datetime": datetime(2024, 9, 25, 12, 0, 0),
+            "gross_amount": Decimal("125.00"),
+            "net_amount": Decimal("100.00"),
+            "ai_status": "completed",
+            "ai_confidence": Decimal("0.92"),
+            "expense_type": "corporate",
+            "tags": "food,lunch",
+            "ocr_raw": "Merchant AB 125.00 SEK",
+        },
+        "items": [
+            {
+                "id": 1,
+                "article_id": "A1",
+                "name": "Lunch",
+                "number": 1,
+                "item_price_ex_vat": Decimal("80.00"),
+                "item_price_inc_vat": Decimal("100.00"),
+                "item_total_price_ex_vat": Decimal("80.00"),
+                "item_total_price_inc_vat": Decimal("100.00"),
+                "currency": "SEK",
+                "vat": Decimal("20.00"),
+                "vat_percentage": Decimal("25.00"),
+            }
+        ],
+        "proposals": [
+            {
+                "id": 1,
+                "account_code": "4010",
+                "debit": Decimal("100.00"),
+                "credit": Decimal("0.00"),
+                "vat_rate": Decimal("25.00"),
+                "notes": "Lunch",
+            }
+        ],
+    }
+
+
+def test_receipt_modal_get(monkeypatch, tmp_path):
+    rid = "RID-100"
+    state = build_initial_state(rid)
+    executed = []
+
+    receipt_dir = tmp_path / rid
+    receipt_dir.mkdir(parents=True, exist_ok=True)
+    boxes = [{"field": "merchant", "x": 0.1, "y": 0.2, "w": 0.3, "h": 0.1}]
+    (receipt_dir / "boxes.json").write_text(json.dumps(boxes), encoding="utf-8")
+
+    app = prepare_app(monkeypatch, tmp_path, state, executed)
+    client = app.test_client()
+
+    response = client.get(f"/receipts/{rid}/modal")
+    assert response.status_code == 200
+    payload = response.get_json()
+
+    assert payload["receipt"]["merchant"] == "Merchant AB"
+    assert payload["items"][0]["name"] == "Lunch"
+    assert payload["proposals"][0]["account"] == "4010"
+    assert payload["boxes"][0]["field"] == "merchant"
+    # Ensure DB was queried for all sections
+    assert any("FROM unified_files" in sql for sql, _ in executed)
+    assert any("FROM receipt_items" in sql for sql, _ in executed)
+    assert any("FROM ai_accounting_proposals" in sql for sql, _ in executed)
+
+
+def test_receipt_modal_put_updates_entities(monkeypatch, tmp_path):
+    rid = "RID-200"
+    state = build_initial_state(rid)
+    executed = []
+
+    receipt_dir = tmp_path / rid
+    receipt_dir.mkdir(parents=True, exist_ok=True)
+    (receipt_dir / "boxes.json").write_text("[]", encoding="utf-8")
+
+    app = prepare_app(monkeypatch, tmp_path, state, executed)
+    client = app.test_client()
+
+    payload = {
+        "receipt": {"merchant": "New Merchant", "gross_amount": 150.5},
+        "items": [
+            {
+                "name": "Dinner",
+                "number": 2,
+                "item_price_inc_vat": 50.25,
+                "item_total_price_inc_vat": 100.5,
+                "item_price_ex_vat": 40.2,
+                "item_total_price_ex_vat": 80.4,
+                "vat": 20.1,
+                "vat_percentage": 25,
+                "currency": "SEK",
+            }
+        ],
+        "proposals": [
+            {"account": "5810", "debit": 100.5, "credit": 0, "vat_rate": 25, "notes": "Dinner"}
+        ],
+    }
+
+    response = client.put(f"/receipts/{rid}/modal", json=payload)
+    assert response.status_code == 200
+    data = response.get_json()
+
+    assert data["receipt_updated"] is True
+    assert data["items_updated"] is True
+    assert data["proposals_updated"] is True
+    assert data["data"]["receipt"]["merchant"] == "New Merchant"
+    assert data["data"]["items"][0]["name"] == "Dinner"
+    assert data["data"]["proposals"][0]["account"] == "5810"
+
+    joined_sql = "\n".join(sql for sql, _ in executed)
+    assert "UPDATE unified_files" in joined_sql
+    assert "DELETE FROM receipt_items" in joined_sql
+    assert "INSERT INTO receipt_items" in joined_sql
+    assert "DELETE FROM ai_accounting_proposals" in joined_sql
+    assert "INSERT INTO ai_accounting_proposals" in joined_sql

--- a/main-system/app-frontend/src/index.css
+++ b/main-system/app-frontend/src/index.css
@@ -654,6 +654,20 @@ input::placeholder {
   flex-direction: column;
 }
 
+.modal-xxl {
+  max-width: 1200px;
+  width: 96vw;
+  height: 92vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.modal-xxl .modal-body {
+  flex: 1;
+  min-height: 0;
+  padding: 0;
+}
+
 .modal-lg .modal-body {
   flex: 1;
   min-height: 0;
@@ -751,6 +765,234 @@ input::placeholder {
   border-radius: 0.75rem;
   border: 1px dashed var(--border-color);
   color: var(--text-secondary);
+}
+
+.receipt-preview-modal {
+  background: var(--bg-primary);
+}
+
+.receipt-modal-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.receipt-modal-content {
+  flex: 1;
+  display: grid;
+  grid-template-columns: 320px 1fr 340px;
+  gap: 1.5rem;
+  padding: 1.5rem;
+  overflow: hidden;
+}
+
+@media (max-width: 1200px) {
+  .receipt-modal-content {
+    grid-template-columns: 280px 1fr 300px;
+  }
+}
+
+@media (max-width: 1024px) {
+  .receipt-modal-content {
+    grid-template-columns: 1fr;
+    overflow-y: auto;
+  }
+}
+
+.receipt-modal-column {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  min-height: 0;
+}
+
+.receipt-modal-section {
+  background: rgba(26, 32, 44, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  min-height: 0;
+}
+
+.receipt-modal-section h4 {
+  margin: 0 0 0.75rem;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+}
+
+.receipt-modal-field {
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  border-radius: 0.65rem;
+  padding: 0.65rem 0.75rem;
+  margin-bottom: 0.65rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.receipt-modal-field.highlighted {
+  border-color: rgba(253, 224, 71, 0.9);
+  background: rgba(253, 224, 71, 0.12);
+  box-shadow: 0 0 0 1px rgba(253, 224, 71, 0.35);
+}
+
+.receipt-modal-field.muted {
+  opacity: 0.45;
+}
+
+.receipt-modal-field .dm-input {
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  color: var(--text-primary);
+}
+
+.receipt-modal-field .field-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+  margin-bottom: 0.35rem;
+}
+
+.receipt-modal-field .field-value {
+  font-size: 0.95rem;
+  color: var(--text-primary);
+}
+
+.receipt-modal-image-wrapper {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  border-radius: 0.9rem;
+  background: rgba(15, 23, 42, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.1);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.receipt-modal-image {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+}
+
+.receipt-modal-image-fallback {
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+}
+
+.receipt-modal-overlay {
+  position: absolute;
+  border: 2px solid rgba(253, 224, 71, 0.7);
+  background: rgba(253, 224, 71, 0.18);
+  transition: opacity 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+}
+
+.receipt-modal-overlay.highlighted {
+  border-color: rgba(253, 224, 71, 0.95);
+  background: rgba(253, 224, 71, 0.32);
+  z-index: 2;
+}
+
+.receipt-modal-overlay.muted {
+  opacity: 0.25;
+}
+
+.receipt-modal-loading {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  color: var(--text-secondary);
+}
+
+.receipt-modal-footer {
+  padding: 1rem 1.5rem 1.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1rem;
+  border-top: 1px solid var(--border-color);
+}
+
+.receipt-modal-footer .footer-hint {
+  flex: 1;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+
+.modal-footer-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.receipt-item-card {
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  border-radius: 0.75rem;
+  padding: 0.75rem;
+  background: rgba(15, 23, 42, 0.6);
+  margin-bottom: 1rem;
+}
+
+.receipt-item-header {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  margin-bottom: 0.5rem;
+}
+
+.proposal-group {
+  margin-top: 0.75rem;
+}
+
+.proposal-group-header {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+  margin-bottom: 0.5rem;
+}
+
+.proposal-card {
+  border: 1px solid rgba(148, 163, 184, 0.15);
+  border-radius: 0.65rem;
+  padding: 0.6rem;
+  background: rgba(15, 23, 42, 0.45);
+  margin-bottom: 0.6rem;
+}
+
+.proposal-field {
+  margin-bottom: 0.5rem;
+}
+
+.proposal-field:last-child {
+  margin-bottom: 0;
+}
+
+.muted {
+  color: var(--text-secondary);
+  opacity: 0.75;
+}
+
+.ocr-section .ocr-content {
+  max-height: 180px;
+  overflow-y: auto;
+  font-size: 0.85rem;
+  line-height: 1.4;
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: 0.5rem;
+  padding: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.proposal-card .dm-input,
+.receipt-item-card .dm-input {
+  font-size: 0.85rem;
 }
 
 /* Tables */

--- a/main-system/app-frontend/src/ui/pages/Receipts.jsx
+++ b/main-system/app-frontend/src/ui/pages/Receipts.jsx
@@ -628,7 +628,7 @@ function ReceiptPreviewModal({ open, receipt, previewImage, onClose, onReceiptUp
     const serialisedItems = draft.items.map((item) => ({
       article_id: item.article_id || '',
       name: item.name || '',
-      number: item.number === '' ? null : Number(item.number),
+      number: item.number === '' ? null : (isNaN(Number(item.number)) ? null : Number(item.number)),
       item_price_ex_vat: item.item_price_ex_vat,
       item_price_inc_vat: item.item_price_inc_vat,
       item_total_price_ex_vat: item.item_total_price_ex_vat,


### PR DESCRIPTION
## Summary
- implement backend receipt modal modal endpoints and normalization helpers
- add React receipt preview modal workflow with supporting styles
- cover modal data flows with targeted unit tests

## Testing
- pytest backend/tests/unit/test_receipt_modal_api.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e10190e050832484ba98dbfd9de6b4