### PR TITLE
Define invoice processing status lifecycle

### DIFF
--- a/backend/src/observability/metrics.py
+++ b/backend/src/observability/metrics.py
@@ -36,6 +36,12 @@ INVOICE_MATCH_COUNT = Counter(
     ["decision"],  # matched|rejected|confirmed|unmatched
 )
 
+INVOICE_STATE_ASSERTIONS = Counter(
+    "mind_invoice_state_assertions_total",
+    "Illegal invoice lifecycle transitions detected",
+    ["entity", "from_state", "to_state"],
+)
+
 
 def metrics_endpoint() -> Response:
     return Response(generate_latest(), mimetype=CONTENT_TYPE_LATEST)
@@ -79,5 +85,16 @@ def track_task(task_name: str):
 def record_invoice_decision(decision: str) -> None:
     try:
         INVOICE_MATCH_COUNT.labels(decision=decision).inc()
+    except Exception:
+        pass
+
+
+def record_invoice_state_assertion(entity: str, from_state: str | None, to_state: str) -> None:
+    try:
+        INVOICE_STATE_ASSERTIONS.labels(
+            entity=entity,
+            from_state=(from_state or "missing"),
+            to_state=to_state,
+        ).inc()
     except Exception:
         pass

--- a/backend/src/services/invoice_status.py
+++ b/backend/src/services/invoice_status.py
@@ -1,0 +1,324 @@
+"""Invoice processing state machine helpers.
+
+This module centralises the lifecycle rules for invoice processing.
+
+There are three parallel state machines:
+
+* ``invoice_documents.processing_status`` tracks the technical pipeline
+  (upload, OCR, AI extraction, matching, completion, failure).
+* ``invoice_documents.status`` represents the business-facing state shown
+  to users (imported, matched, completed, failed, etc.).
+* ``invoice_lines.match_status`` captures progress for individual
+  transaction lines (pending, auto, manual, confirmed, unmatched).
+
+Each transition is validated and executed atomically in the database using
+``WHERE`` clauses that assert the current state. If the row update fails the
+helper records an observability metric and logs a warning. This protects the
+pipeline from accidental regressions or race conditions where two workers try
+ to update the same document concurrently.
+"""
+
+from __future__ import annotations
+
+import logging
+from enum import Enum
+from typing import Iterable
+
+try:  # pragma: no cover - imported lazily during tests
+    from services.db.connection import db_cursor
+except Exception:  # pragma: no cover
+    db_cursor = None  # type: ignore
+
+from observability.metrics import record_invoice_state_assertion
+
+
+logger = logging.getLogger(__name__)
+
+
+class InvoiceProcessingStatus(str, Enum):
+    """Technical processing states for ``invoice_documents``."""
+
+    UPLOADED = "uploaded"
+    OCR_PENDING = "ocr_pending"
+    OCR_DONE = "ocr_done"
+    AI_PROCESSING = "ai_processing"
+    READY_FOR_MATCHING = "ready_for_matching"
+    MATCHING_COMPLETED = "matching_completed"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class InvoiceDocumentStatus(str, Enum):
+    """Business lifecycle states exposed to end users."""
+
+    IMPORTED = "imported"
+    MATCHING = "matching"
+    MATCHED = "matched"
+    PARTIALLY_MATCHED = "partially_matched"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class InvoiceLineMatchStatus(str, Enum):
+    """Per-line reconciliation states."""
+
+    PENDING = "pending"
+    AUTO = "auto"
+    MANUAL = "manual"
+    CONFIRMED = "confirmed"
+    UNMATCHED = "unmatched"
+    IGNORED = "ignored"
+
+
+# Allowed transitions expressed as ``current -> {next}``
+PROCESSING_TRANSITIONS: dict[InvoiceProcessingStatus, set[InvoiceProcessingStatus]] = {
+    InvoiceProcessingStatus.UPLOADED: {
+        InvoiceProcessingStatus.OCR_PENDING,
+        InvoiceProcessingStatus.READY_FOR_MATCHING,  # manual JSON import can skip OCR
+        InvoiceProcessingStatus.FAILED,
+    },
+    InvoiceProcessingStatus.OCR_PENDING: {
+        InvoiceProcessingStatus.OCR_DONE,
+        InvoiceProcessingStatus.FAILED,
+    },
+    InvoiceProcessingStatus.OCR_DONE: {
+        InvoiceProcessingStatus.AI_PROCESSING,
+        InvoiceProcessingStatus.READY_FOR_MATCHING,  # allow direct fallback when OCR already contains data
+        InvoiceProcessingStatus.FAILED,
+    },
+    InvoiceProcessingStatus.AI_PROCESSING: {
+        InvoiceProcessingStatus.READY_FOR_MATCHING,
+        InvoiceProcessingStatus.FAILED,
+    },
+    InvoiceProcessingStatus.READY_FOR_MATCHING: {
+        InvoiceProcessingStatus.MATCHING_COMPLETED,
+        InvoiceProcessingStatus.FAILED,
+    },
+    InvoiceProcessingStatus.MATCHING_COMPLETED: {
+        InvoiceProcessingStatus.COMPLETED,
+    },
+    InvoiceProcessingStatus.COMPLETED: set(),
+    InvoiceProcessingStatus.FAILED: set(),
+}
+
+DOCUMENT_STATUS_TRANSITIONS: dict[InvoiceDocumentStatus, set[InvoiceDocumentStatus]] = {
+    InvoiceDocumentStatus.IMPORTED: {
+        InvoiceDocumentStatus.MATCHING,
+        InvoiceDocumentStatus.MATCHED,
+        InvoiceDocumentStatus.PARTIALLY_MATCHED,
+        InvoiceDocumentStatus.FAILED,
+    },
+    InvoiceDocumentStatus.MATCHING: {
+        InvoiceDocumentStatus.MATCHED,
+        InvoiceDocumentStatus.PARTIALLY_MATCHED,
+        InvoiceDocumentStatus.FAILED,
+    },
+    InvoiceDocumentStatus.MATCHED: {
+        InvoiceDocumentStatus.COMPLETED,
+        InvoiceDocumentStatus.PARTIALLY_MATCHED,
+    },
+    InvoiceDocumentStatus.PARTIALLY_MATCHED: {
+        InvoiceDocumentStatus.MATCHED,
+        InvoiceDocumentStatus.COMPLETED,
+        InvoiceDocumentStatus.FAILED,
+    },
+    InvoiceDocumentStatus.COMPLETED: set(),
+    InvoiceDocumentStatus.FAILED: set(),
+}
+
+LINE_STATUS_TRANSITIONS: dict[InvoiceLineMatchStatus, set[InvoiceLineMatchStatus]] = {
+    InvoiceLineMatchStatus.PENDING: {
+        InvoiceLineMatchStatus.AUTO,
+        InvoiceLineMatchStatus.MANUAL,
+        InvoiceLineMatchStatus.UNMATCHED,
+        InvoiceLineMatchStatus.IGNORED,
+    },
+    InvoiceLineMatchStatus.AUTO: {
+        InvoiceLineMatchStatus.MANUAL,
+        InvoiceLineMatchStatus.CONFIRMED,
+        InvoiceLineMatchStatus.UNMATCHED,
+    },
+    InvoiceLineMatchStatus.MANUAL: {
+        InvoiceLineMatchStatus.CONFIRMED,
+        InvoiceLineMatchStatus.UNMATCHED,
+    },
+    InvoiceLineMatchStatus.CONFIRMED: set(),
+    InvoiceLineMatchStatus.UNMATCHED: {
+        InvoiceLineMatchStatus.MANUAL,
+    },
+    InvoiceLineMatchStatus.IGNORED: {
+        InvoiceLineMatchStatus.MANUAL,
+    },
+}
+
+
+def _record_illegal(entity: str, object_id: str, target: str) -> None:
+    """Log and emit metrics for illegal transitions."""
+
+    current_value = "missing"
+    if db_cursor is not None:
+        column = "processing_status" if entity == "processing_status" else "status"
+        if entity == "line_match_status":
+            column = "match_status"
+            query = "SELECT match_status FROM invoice_lines WHERE id=%s"
+            params = (object_id,)
+        else:
+            query = f"SELECT {column} FROM invoice_documents WHERE id=%s"
+            params = (object_id,)
+        try:
+            with db_cursor() as cur:
+                cur.execute(query, params)
+                row = cur.fetchone()
+            if row:
+                current_value = row[0] or "null"
+        except Exception:  # pragma: no cover - defensive logging path
+            logger.exception("Failed to fetch current invoice state for assertion")
+    record_invoice_state_assertion(entity, current_value, target)
+    logger.warning(
+        "Illegal transition for %s id=%s: current=%s target=%s", entity, object_id, current_value, target
+    )
+
+
+def transition_processing_status(
+    document_id: str,
+    target: InvoiceProcessingStatus,
+    allowed_from: Iterable[InvoiceProcessingStatus],
+) -> bool:
+    """Atomically update ``invoice_documents.processing_status``.
+
+    Args:
+        document_id: Invoice identifier.
+        target: Target processing state.
+        allowed_from: One or more current states that may transition into ``target``.
+    """
+
+    states = tuple(allowed_from)
+    if not states:
+        raise ValueError("allowed_from must contain at least one state")
+    if db_cursor is None:
+        return False
+    placeholders = ", ".join(["%s"] * len(states))
+    sql = (
+        f"UPDATE invoice_documents SET processing_status=%s "
+        f"WHERE id=%s AND processing_status IN ({placeholders})"
+    )
+    params: tuple[object, ...] = (target.value, document_id, *[state.value for state in states])
+    try:
+        with db_cursor() as cur:
+            cur.execute(sql, params)
+            if cur.rowcount:
+                return True
+    except Exception:
+        logger.exception("Failed to update invoice processing status")
+        raise
+    _record_illegal("processing_status", document_id, target.value)
+    return False
+
+
+def transition_document_status(
+    document_id: str,
+    target: InvoiceDocumentStatus,
+    allowed_from: Iterable[InvoiceDocumentStatus],
+) -> bool:
+    states = tuple(allowed_from)
+    if not states:
+        raise ValueError("allowed_from must contain at least one state")
+    if db_cursor is None:
+        return False
+    placeholders = ", ".join(["%s"] * len(states))
+    sql = f"UPDATE invoice_documents SET status=%s WHERE id=%s AND status IN ({placeholders})"
+    params: tuple[object, ...] = (target.value, document_id, *[state.value for state in states])
+    try:
+        with db_cursor() as cur:
+            cur.execute(sql, params)
+            if cur.rowcount:
+                return True
+    except Exception:
+        logger.exception("Failed to update invoice document status")
+        raise
+    _record_illegal("status", document_id, target.value)
+    return False
+
+
+def transition_line_status(
+    line_id: int,
+    target: InvoiceLineMatchStatus,
+    allowed_from: Iterable[InvoiceLineMatchStatus],
+) -> bool:
+    states = tuple(allowed_from)
+    if not states:
+        raise ValueError("allowed_from must contain at least one state")
+    if db_cursor is None:
+        return False
+    placeholders = ", ".join(["%s"] * len(states))
+    sql = (
+        f"UPDATE invoice_lines SET match_status=%s WHERE id=%s "
+        f"AND (match_status IS NULL OR match_status IN ({placeholders}))"
+    )
+    params: tuple[object, ...] = (target.value, line_id, *[state.value for state in states])
+    try:
+        with db_cursor() as cur:
+            cur.execute(sql, params)
+            if cur.rowcount:
+                return True
+    except Exception:
+        logger.exception("Failed to update invoice line status")
+        raise
+    _record_illegal("line_match_status", str(line_id), target.value)
+    return False
+
+
+def transition_line_status_and_link(
+    line_id: int,
+    matched_file_id: str,
+    score: float | None,
+    target: InvoiceLineMatchStatus,
+    allowed_from: Iterable[InvoiceLineMatchStatus],
+) -> bool:
+    """Update ``match_status`` together with ``matched_file_id`` and ``match_score``."""
+
+    states = tuple(allowed_from)
+    if not states:
+        raise ValueError("allowed_from must contain at least one state")
+    if db_cursor is None:
+        return False
+    placeholders = ", ".join(["%s"] * len(states))
+    sql = (
+        "UPDATE invoice_lines SET matched_file_id=%s, match_score=%s, match_status=%s "
+        "WHERE id=%s AND (match_status IS NULL OR match_status IN ({placeholders}))"
+    ).format(placeholders=placeholders)
+    params: tuple[object, ...] = (
+        matched_file_id,
+        score,
+        target.value,
+        line_id,
+        *[state.value for state in states],
+    )
+    try:
+        with db_cursor() as cur:
+            cur.execute(sql, params)
+            if cur.rowcount:
+                return True
+    except Exception:
+        logger.exception("Failed to link invoice line to receipt")
+        raise
+    _record_illegal("line_match_status", str(line_id), target.value)
+    return False
+
+
+def reset_line_match(line_id: int) -> bool:
+    """Reset an invoice line to ``pending`` when an auto-match fails."""
+
+    if db_cursor is None:
+        return False
+    sql = (
+        "UPDATE invoice_lines SET matched_file_id=NULL, match_score=NULL, match_status=%s "
+        "WHERE id=%s"
+    )
+    try:
+        with db_cursor() as cur:
+            cur.execute(sql, (InvoiceLineMatchStatus.PENDING.value, line_id))
+            return cur.rowcount > 0
+    except Exception:
+        logger.exception("Failed to reset invoice line state")
+        raise

--- a/backend/src/services/invoice_status.py
+++ b/backend/src/services/invoice_status.py
@@ -284,9 +284,9 @@ def transition_line_status_and_link(
         return False
     placeholders = ", ".join(["%s"] * len(states))
     sql = (
-        "UPDATE invoice_lines SET matched_file_id=%s, match_score=%s, match_status=%s "
-        "WHERE id=%s AND (match_status IS NULL OR match_status IN ({placeholders}))"
-    ).format(placeholders=placeholders)
+        f"UPDATE invoice_lines SET matched_file_id=%s, match_score=%s, match_status=%s "
+        f"WHERE id=%s AND (match_status IS NULL OR match_status IN ({placeholders}))"
+    )
     params: tuple[object, ...] = (
         matched_file_id,
         score,

--- a/backend/tests/integration/test_firstcard_invoice_flow.py
+++ b/backend/tests/integration/test_firstcard_invoice_flow.py
@@ -75,7 +75,13 @@ class FakeDB:
             }
             self._lastrowid += 1
         elif s.startswith("insert into invoice_lines"):
-            invoice_id, tx_date, amount, merchant_name, description, match_status = p
+            if len(p) == 6:
+                invoice_id, tx_date, amount, merchant_name, description, match_status = p
+            elif len(p) == 5:
+                invoice_id, tx_date, amount, merchant_name, description = p
+                match_status = None  # or "pending" if that's the default in your app
+            else:
+                raise ValueError(f"Unexpected number of parameters for invoice_lines insert: {len(p)}")
             self._lastrowid += 1
             self.lines.append(
                 {

--- a/backend/tests/integration/test_firstcard_invoice_flow.py
+++ b/backend/tests/integration/test_firstcard_invoice_flow.py
@@ -7,6 +7,28 @@ from contextlib import contextmanager
 def import_app(monkeypatch):
     # Disable auto-migrate during tests
     monkeypatch.setenv("DB_AUTO_MIGRATE", "0")
+    import sys
+    import types
+
+    if "flask_limiter" not in sys.modules:
+        limiter_ns = types.SimpleNamespace()
+
+        class DummyLimiter:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def init_app(self, _app):  # pragma: no cover - simple stub
+                return None
+
+            def limit(self, *args, **kwargs):
+                def _decorator(func):
+                    return func
+
+                return _decorator
+
+        limiter_ns.Limiter = DummyLimiter
+        sys.modules["flask_limiter"] = limiter_ns
+        sys.modules.setdefault("flask_limiter.util", types.SimpleNamespace(get_remote_address=lambda *_args, **_kwargs: "0.0.0.0"))
     root = Path(__file__).resolve().parents[2]
     src = root / "src"
     if str(src) not in sys.path:
@@ -23,6 +45,7 @@ class FakeDB:
         self.history = []
         self._results = None
         self._lastrowid = 0
+        self._rowcount = 0
 
     @contextmanager
     def cursor(self):
@@ -39,6 +62,7 @@ class FakeDB:
     def execute(self, sql, params=None):
         s = " ".join(str(sql).split()).lower()
         p = params or ()
+        self._rowcount = 0
         if s.startswith("insert into invoice_documents"):
             doc_id, inv_type, ps, pe = p
             self.documents[doc_id] = {
@@ -47,10 +71,11 @@ class FakeDB:
                 "period_end": pe,
                 "status": "imported",
                 "uploaded_at": "2025-09-20",
+                "processing_status": "uploaded",
             }
             self._lastrowid += 1
         elif s.startswith("insert into invoice_lines"):
-            invoice_id, tx_date, amount, merchant_name, description = p
+            invoice_id, tx_date, amount, merchant_name, description, match_status = p
             self._lastrowid += 1
             self.lines.append(
                 {
@@ -61,39 +86,89 @@ class FakeDB:
                     "merchant_name": merchant_name,
                     "description": description,
                     "matched_file_id": None,
-                    "match_status": None,
+                    "match_status": match_status,
                 }
             )
+            self._rowcount = 1
         elif s.startswith("select id, transaction_date, amount from invoice_lines"):
             invoice_id = p[0]
             rows = [
                 (ln["id"], ln["transaction_date"], ln["amount"])
                 for ln in self.lines
-                if ln["invoice_id"] == invoice_id and ln["matched_file_id"] is None
+                if ln["invoice_id"] == invoice_id
+                and (ln["match_status"] in (None, "pending", "unmatched"))
             ]
             self._results = rows
+        elif s.startswith("select count(*) from invoice_lines"):
+            invoice_id = p[0]
+            count = sum(1 for ln in self.lines if ln["invoice_id"] == invoice_id)
+            self._results = [(count,)]
         elif s.startswith("select id from unified_files"):
             # Simulate a matching receipt id for our test
             self._results = [("receipt-1",)]
         elif s.startswith("update invoice_lines set matched_file_id"):
-            file_id, score, line_id = p
+            file_id, score, new_status, line_id, *allowed = p
             for ln in self.lines:
                 if ln["id"] == line_id:
-                    ln["matched_file_id"] = file_id
-                    ln["match_status"] = "auto"
+                    current = ln["match_status"]
+                    allowed_states = {None if a is None else a for a in allowed}
+                    if current in allowed_states or current is None:
+                        ln["matched_file_id"] = file_id
+                        ln["match_status"] = new_status
+                        self._rowcount = 1
                     break
         elif s.startswith("insert into invoice_line_history"):
             line_id, new_file_id = p
             self.history.append({"line": line_id, "new": new_file_id})
             self._lastrowid += 1
+            self._rowcount = 1
         elif s.startswith("update invoice_documents set status='matched'"):
             doc_id = p[0]
             if doc_id in self.documents:
                 self.documents[doc_id]["status"] = "matched"
+                self._rowcount = 1
         elif s.startswith("update invoice_documents set status='completed'"):
             doc_id = p[0]
             if doc_id in self.documents:
                 self.documents[doc_id]["status"] = "completed"
+                self._rowcount = 1
+        elif s.startswith("update invoice_documents set status=%s"):
+            new_status, doc_id, *allowed = p
+            doc = self.documents.get(doc_id)
+            if doc and doc["status"] in allowed:
+                doc["status"] = new_status
+                self._rowcount = 1
+        elif s.startswith("update invoice_documents set processing_status=%s"):
+            new_status, doc_id, *allowed = p
+            doc = self.documents.get(doc_id)
+            if doc and doc.get("processing_status") in allowed:
+                doc["processing_status"] = new_status
+                self._rowcount = 1
+        elif s.startswith("select processing_status from invoice_documents"):
+            doc_id = p[0]
+            doc = self.documents.get(doc_id)
+            self._results = [(doc.get("processing_status"),)] if doc else []
+        elif s.startswith("select status from invoice_documents"):
+            doc_id = p[0]
+            doc = self.documents.get(doc_id)
+            self._results = [(doc.get("status"),)] if doc else []
+        elif s.startswith("select match_status from invoice_lines"):
+            line_id = int(p[0])
+            for ln in self.lines:
+                if ln["id"] == line_id:
+                    self._results = [(ln["match_status"],)]
+                    break
+        elif s.startswith("select count(*), sum(case when match_status"):
+            invoice_id = p[0]
+            total = 0
+            matched = 0
+            for ln in self.lines:
+                if ln["invoice_id"] != invoice_id:
+                    continue
+                total += 1
+                if ln["match_status"] in ("auto", "manual", "confirmed"):
+                    matched += 1
+            self._results = [(total, matched)]
         elif s.startswith("select id, uploaded_at, status from invoice_documents"):
             rows = [
                 (doc_id, doc["uploaded_at"], doc["status"])
@@ -117,6 +192,10 @@ class FakeDB:
     def lastrowid(self):
         return self._lastrowid
 
+    @property
+    def rowcount(self):
+        return self._rowcount
+
 
 def test_firstcard_import_match_confirm(monkeypatch):
     app = import_app(monkeypatch)
@@ -133,6 +212,8 @@ def test_firstcard_import_match_confirm(monkeypatch):
 
     # Overwrite the module-level db_cursor used by the blueprint
     mod.db_cursor = fake_db_cursor  # type: ignore
+    status_mod = import_module("services.invoice_status")
+    status_mod.db_cursor = fake_db_cursor  # type: ignore
 
     # 1) Import statement with a single line
     body = {
@@ -151,6 +232,7 @@ def test_firstcard_import_match_confirm(monkeypatch):
     assert r1.status_code == 200
     doc_id = r1.get_json()["id"]
     assert fake.documents[doc_id]["status"] == "imported"
+    assert fake.documents[doc_id]["processing_status"] == "ready_for_matching"
 
     # 2) Match
     r2 = client.post("/reconciliation/firstcard/match", json={"document_id": doc_id})
@@ -159,6 +241,7 @@ def test_firstcard_import_match_confirm(monkeypatch):
     # Confirm line marked matched
     assert fake.lines[0]["matched_file_id"] == "receipt-1"
     assert fake.documents[doc_id]["status"] == "matched"
+    assert fake.documents[doc_id]["processing_status"] == "matching_completed"
 
     # 3) List statements
     r3 = client.get("/reconciliation/firstcard/statements")
@@ -170,4 +253,5 @@ def test_firstcard_import_match_confirm(monkeypatch):
     r4 = client.post(f"/reconciliation/firstcard/statements/{doc_id}/confirm")
     assert r4.status_code == 200
     assert fake.documents[doc_id]["status"] == "completed"
+    assert fake.documents[doc_id]["processing_status"] == "completed"
 

--- a/backend/tests/unit/test_invoice_status.py
+++ b/backend/tests/unit/test_invoice_status.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+import pytest
+
+from services import invoice_status
+from services.invoice_status import (
+    InvoiceDocumentStatus,
+    InvoiceLineMatchStatus,
+    InvoiceProcessingStatus,
+)
+
+
+class MiniCursor:
+    def __init__(self, documents: dict[str, dict[str, str]], lines: dict[int, dict[str, str | None]]):
+        self.documents = documents
+        self.lines = lines
+        self._results: list[tuple] = []
+        self._rowcount = 0
+
+    def __enter__(self) -> "MiniCursor":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+    def execute(self, sql: str, params: tuple | list | None = None) -> None:
+        params = tuple(params or ())
+        statement = " ".join(sql.split()).lower()
+        self._rowcount = 0
+        if statement.startswith("update invoice_documents set processing_status=%s"):
+            new_status, doc_id, *allowed = params
+            doc = self.documents.get(doc_id)
+            if doc and doc.get("processing_status") in allowed:
+                doc["processing_status"] = new_status
+                self._rowcount = 1
+        elif statement.startswith("select processing_status from invoice_documents"):
+            doc_id = params[0]
+            doc = self.documents.get(doc_id)
+            self._results = [(doc.get("processing_status"),)] if doc else []
+        elif statement.startswith("update invoice_documents set status=%s"):
+            new_status, doc_id, *allowed = params
+            doc = self.documents.get(doc_id)
+            if doc and doc.get("status") in allowed:
+                doc["status"] = new_status
+                self._rowcount = 1
+        elif statement.startswith("select status from invoice_documents"):
+            doc_id = params[0]
+            doc = self.documents.get(doc_id)
+            self._results = [(doc.get("status"),)] if doc else []
+        elif statement.startswith("update invoice_lines set matched_file_id=%s"):
+            file_id, score, new_status, line_id, *allowed = params
+            line = self.lines.get(int(line_id))
+            if line and line.get("match_status") in allowed:
+                line["matched_file_id"] = file_id
+                line["match_status"] = new_status
+                self._rowcount = 1
+        elif statement.startswith("select match_status from invoice_lines"):
+            line_id = int(params[0])
+            line = self.lines.get(line_id)
+            self._results = [(line.get("match_status"),)] if line else []
+        else:
+            self._results = []
+
+    def fetchone(self):
+        return self._results[0] if self._results else None
+
+    @property
+    def rowcount(self) -> int:
+        return self._rowcount
+
+
+class MiniDB:
+    def __init__(self) -> None:
+        self.documents = {
+            "doc-1": {
+                "processing_status": InvoiceProcessingStatus.UPLOADED.value,
+                "status": InvoiceDocumentStatus.IMPORTED.value,
+            }
+        }
+        self.lines = {
+            1: {
+                "match_status": InvoiceLineMatchStatus.PENDING.value,
+                "matched_file_id": None,
+            }
+        }
+
+    @contextmanager
+    def cursor(self) -> MiniCursor:
+        yield MiniCursor(self.documents, self.lines)
+
+
+@pytest.fixture(autouse=True)
+def restore_db_cursor(monkeypatch):
+    original = invoice_status.db_cursor
+    yield
+    invoice_status.db_cursor = original  # type: ignore
+
+
+def test_transition_processing_status_updates_state(monkeypatch):
+    db = MiniDB()
+    monkeypatch.setattr(invoice_status, "db_cursor", db.cursor)
+    calls: list[tuple] = []
+    monkeypatch.setattr(invoice_status, "record_invoice_state_assertion", lambda *args: calls.append(args))
+
+    ok = invoice_status.transition_processing_status(
+        "doc-1",
+        InvoiceProcessingStatus.OCR_PENDING,
+        (InvoiceProcessingStatus.UPLOADED,),
+    )
+
+    assert ok is True
+    assert db.documents["doc-1"]["processing_status"] == InvoiceProcessingStatus.OCR_PENDING.value
+    assert calls == []
+
+
+def test_transition_processing_status_illegal_emits_metric(monkeypatch):
+    db = MiniDB()
+    db.documents["doc-1"]["processing_status"] = InvoiceProcessingStatus.READY_FOR_MATCHING.value
+    monkeypatch.setattr(invoice_status, "db_cursor", db.cursor)
+    calls: list[tuple] = []
+    monkeypatch.setattr(invoice_status, "record_invoice_state_assertion", lambda *args: calls.append(args))
+
+    ok = invoice_status.transition_processing_status(
+        "doc-1",
+        InvoiceProcessingStatus.OCR_PENDING,
+        (InvoiceProcessingStatus.UPLOADED,),
+    )
+
+    assert ok is False
+    assert calls[0][0] == "processing_status"
+    assert calls[0][1] == InvoiceProcessingStatus.READY_FOR_MATCHING.value
+    assert calls[0][2] == InvoiceProcessingStatus.OCR_PENDING.value
+
+
+def test_transition_line_status_and_link(monkeypatch):
+    db = MiniDB()
+    monkeypatch.setattr(invoice_status, "db_cursor", db.cursor)
+    calls: list[tuple] = []
+    monkeypatch.setattr(invoice_status, "record_invoice_state_assertion", lambda *args: calls.append(args))
+
+    ok = invoice_status.transition_line_status_and_link(
+        1,
+        "receipt-1",
+        0.9,
+        InvoiceLineMatchStatus.AUTO,
+        (InvoiceLineMatchStatus.PENDING,),
+    )
+
+    assert ok is True
+    assert db.lines[1]["matched_file_id"] == "receipt-1"
+    assert db.lines[1]["match_status"] == InvoiceLineMatchStatus.AUTO.value
+    assert calls == []
+
+    # Illegal follow-up transition should emit a metric and keep previous value
+    ok = invoice_status.transition_line_status_and_link(
+        1,
+        "receipt-2",
+        0.8,
+        InvoiceLineMatchStatus.AUTO,
+        (InvoiceLineMatchStatus.PENDING,),
+    )
+
+    assert ok is False
+    assert db.lines[1]["matched_file_id"] == "receipt-1"
+    assert calls[-1][0] == "line_match_status"
+    assert calls[-1][2] == InvoiceLineMatchStatus.AUTO.value


### PR DESCRIPTION
## Summary
- add a dedicated `services.invoice_status` helper that encapsulates processing, document, and line match transitions and emits metrics for illegal changes
- update the FirstCard reconciliation API and Celery tasks to use the lifecycle helpers, ensuring atomic updates and proper status propagation
- document the lifecycle in the implementation plan and add focused unit/integration coverage for the new behaviour

## Testing
- pytest backend/tests/unit/test_invoice_status.py backend/tests/integration/test_firstcard_invoice_flow.py

------
https://chatgpt.com/codex/tasks/task_e_68e1022796a083249c26187e38dac36d