### PR TITLE
Route invoice OCR into dedicated pipeline

### DIFF
--- a/backend/src/services/tasks.py
+++ b/backend/src/services/tasks.py
@@ -5,7 +5,7 @@ import os
 from datetime import datetime, timezone
 from decimal import Decimal
 from pathlib import Path
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Tuple
 
 try:
     from services.db.connection import db_cursor
@@ -244,6 +244,113 @@ def _get_file_type(file_id: str) -> Optional[str]:
     except Exception:
         return None
     return None
+
+
+_INVOICE_OCR_COMPLETE_STATUSES = {
+    "ocr_done",
+    "ready_for_matching",
+    "matching_completed",
+    "completed",
+}
+
+
+def _get_invoice_parent_id(file_id: str, file_type: Optional[str]) -> Optional[str]:
+    if file_type == "invoice":
+        return file_id
+    if db_cursor is None:
+        return None
+    try:
+        with db_cursor() as cur:
+            cur.execute("SELECT original_file_id FROM unified_files WHERE id=%s", (file_id,))
+            row = cur.fetchone()
+            if row:
+                (original_file_id,) = row
+                return str(original_file_id) if original_file_id else None
+    except Exception:
+        return None
+    return None
+
+
+def _invoice_page_progress(invoice_id: str) -> Tuple[int, int]:
+    if db_cursor is None:
+        return (0, 0)
+    try:
+        with db_cursor() as cur:
+            cur.execute(
+                """
+                SELECT id, file_type, ai_status
+                  FROM unified_files
+                 WHERE original_file_id=%s AND file_type='invoice_page'
+                """,
+                (invoice_id,),
+            )
+            rows = cur.fetchall() or []
+            total_pages = len(rows)
+            completed_pages = sum(1 for _, _, status in rows if status in _INVOICE_OCR_COMPLETE_STATUSES)
+            if total_pages == 0:
+                cur.execute("SELECT ai_status FROM unified_files WHERE id=%s", (invoice_id,))
+                row = cur.fetchone()
+                status = row[0] if row else None
+                total_pages = 1
+                completed_pages = 1 if status in _INVOICE_OCR_COMPLETE_STATUSES else 0
+            return completed_pages, total_pages
+    except Exception:
+        return (0, 0)
+
+
+def _enqueue_invoice_ai_extraction(invoice_id: str) -> None:
+    try:
+        if hasattr(process_invoice_ai_extraction, "delay"):
+            process_invoice_ai_extraction.delay(invoice_id)  # type: ignore[attr-defined]
+        else:
+            process_invoice_ai_extraction(invoice_id)
+    except Exception:
+        pass
+
+
+def _enqueue_invoice_matching(invoice_id: str) -> None:
+    try:
+        if hasattr(process_invoice_matching, "delay"):
+            process_invoice_matching.delay(invoice_id)  # type: ignore[attr-defined]
+        else:
+            process_invoice_matching(invoice_id)
+    except Exception:
+        pass
+
+
+def _fail_invoice_processing(invoice_id: Optional[str], error_message: Optional[str]) -> None:
+    if not invoice_id:
+        return
+    transitioned = transition_processing_status(
+        invoice_id,
+        InvoiceProcessingStatus.FAILED,
+        (
+            InvoiceProcessingStatus.OCR_PENDING,
+            InvoiceProcessingStatus.UPLOADED,
+            InvoiceProcessingStatus.OCR_DONE,
+            InvoiceProcessingStatus.AI_PROCESSING,
+        ),
+    )
+    if transitioned:
+        transition_document_status(
+            invoice_id,
+            InvoiceDocumentStatus.FAILED,
+            (
+                InvoiceDocumentStatus.IMPORTED,
+                InvoiceDocumentStatus.MATCHING,
+                InvoiceDocumentStatus.PARTIALLY_MATCHED,
+                InvoiceDocumentStatus.MATCHED,
+            ),
+        )
+    _history(
+        invoice_id,
+        job="invoice_ocr",
+        status="error",
+        ai_stage_name="Invoice-OCRFailed",
+        log_text="Invoice OCR processing failed",
+        error_message=error_message,
+        provider="paddleocr",
+    )
 
 
 def _collect_text_hints(file_id: str) -> str:
@@ -769,6 +876,15 @@ def process_ocr(file_id: str) -> dict[str, Any]:
 
     start_time = time.time()
 
+    file_type = _get_file_type(file_id)
+    invoice_id = _get_invoice_parent_id(file_id, file_type)
+    if invoice_id:
+        transition_processing_status(
+            invoice_id,
+            InvoiceProcessingStatus.OCR_PENDING,
+            (InvoiceProcessingStatus.UPLOADED,),
+        )
+
     # Run real OCR
     result: dict[str, Any] | None = None
     error_msg: str | None = None
@@ -807,18 +923,60 @@ def process_ocr(file_id: str) -> dict[str, Any]:
         if detected:
             log_parts.append(f"detected: {', '.join(detected)}")
 
+        history_job = "invoice_ocr" if invoice_id else "ocr"
+        stage_name = "Invoice-OCRPage" if invoice_id else "OCR-TextExtraction"
         _history(
             file_id,
-            job="ocr",
+            job=history_job,
             status="success",
-            ai_stage_name="OCR-TextExtraction",
+            ai_stage_name=stage_name,
             log_text="; ".join(log_parts),
             confidence=None,
             processing_time_ms=elapsed,
             provider="paddleocr",
         )
 
-        # Only continue to AI pipeline if OCR succeeded
+        if invoice_id:
+            completed_pages, total_pages = _invoice_page_progress(invoice_id)
+            if total_pages and completed_pages >= total_pages:
+                transitioned = transition_processing_status(
+                    invoice_id,
+                    InvoiceProcessingStatus.OCR_DONE,
+                    (
+                        InvoiceProcessingStatus.OCR_PENDING,
+                        InvoiceProcessingStatus.UPLOADED,
+                    ),
+                )
+                if transitioned:
+                    _history(
+                        invoice_id,
+                        job="invoice_ocr",
+                        status="success",
+                        ai_stage_name="Invoice-OCRComplete",
+                        log_text=f"Completed OCR for invoice: pages={completed_pages}",
+                        processing_time_ms=elapsed,
+                        provider="paddleocr",
+                    )
+                    transition_document_status(
+                        invoice_id,
+                        InvoiceDocumentStatus.MATCHING,
+                        (
+                            InvoiceDocumentStatus.IMPORTED,
+                            InvoiceDocumentStatus.MATCHING,
+                        ),
+                    )
+                _enqueue_invoice_ai_extraction(invoice_id)
+            return {
+                "file_id": file_id,
+                "status": "ocr_done",
+                "ok": ok,
+                "real": True,
+                "invoice_id": invoice_id,
+                "pages_completed": completed_pages,
+                "pages_total": total_pages,
+            }
+
+        # Only continue to AI pipeline if OCR succeeded for receipts
         try:
             process_ai_pipeline.delay(file_id)  # type: ignore[attr-defined]
         except Exception:
@@ -833,17 +991,23 @@ def process_ocr(file_id: str) -> dict[str, Any]:
         ok = _update_file_status(file_id, status="manual_review", confidence=0.0)
         elapsed = int((time.time() - start_time) * 1000)
 
+        history_job = "invoice_ocr" if invoice_id else "ocr"
+        stage_name = "Invoice-OCRPage" if invoice_id else "OCR-TextExtraction"
+
         _history(
             file_id,
-            job="ocr",
+            job=history_job,
             status="error",
-            ai_stage_name="OCR-TextExtraction",
+            ai_stage_name=stage_name,
             log_text="OCR processing failed or returned no results",
             error_message=error_msg or "OCR returned no results",
             confidence=0.0,
             processing_time_ms=elapsed,
             provider="paddleocr",
         )
+
+        if invoice_id:
+            _fail_invoice_processing(invoice_id, error_msg)
 
         return {"file_id": file_id, "status": "manual_review", "ok": False, "error": error_msg or "OCR failed"}
 
@@ -1060,8 +1224,8 @@ def process_accounting_proposal(file_id: str) -> dict[str, Any]:
 
 
 @celery_app.task
-@track_task("process_invoice_document")
-def process_invoice_document(document_id: str) -> dict[str, Any]:
+@track_task("process_invoice_ai_extraction")
+def process_invoice_ai_extraction(document_id: str) -> dict[str, Any]:
     transitioned = transition_processing_status(
         document_id,
         InvoiceProcessingStatus.AI_PROCESSING,
@@ -1072,7 +1236,13 @@ def process_invoice_document(document_id: str) -> dict[str, Any]:
         ),
     )
     if not transitioned:
-        _history(document_id, job="invoice_document", status="error", log_text="invalid_processing_state")
+        _history(
+            document_id,
+            job="invoice_ai",
+            status="error",
+            ai_stage_name="Invoice-AIExtraction",
+            log_text="Invalid processing state for invoice AI extraction",
+        )
         return {
             "document_id": document_id,
             "status": "invalid_state",
@@ -1081,7 +1251,13 @@ def process_invoice_document(document_id: str) -> dict[str, Any]:
 
     # Placeholder for AI extraction work. Once implemented this block will call
     # the dedicated invoice extraction service and populate invoice_lines.
-    _history(document_id, job="invoice_document", status="success", log_text="ai_processing_started")
+    _history(
+        document_id,
+        job="invoice_ai",
+        status="success",
+        ai_stage_name="Invoice-AIExtraction",
+        log_text="Invoice AI extraction placeholder executed",
+    )
 
     ready = transition_processing_status(
         document_id,
@@ -1092,8 +1268,12 @@ def process_invoice_document(document_id: str) -> dict[str, Any]:
         transition_document_status(
             document_id,
             InvoiceDocumentStatus.MATCHING,
-            (InvoiceDocumentStatus.IMPORTED,),
+            (
+                InvoiceDocumentStatus.IMPORTED,
+                InvoiceDocumentStatus.MATCHING,
+            ),
         )
+        _enqueue_invoice_matching(document_id)
     return {
         "document_id": document_id,
         "status": InvoiceProcessingStatus.READY_FOR_MATCHING.value,
@@ -1102,8 +1282,8 @@ def process_invoice_document(document_id: str) -> dict[str, Any]:
 
 
 @celery_app.task
-@track_task("process_matching")
-def process_matching(statement_id: str) -> dict[str, Any]:
+@track_task("process_invoice_matching")
+def process_invoice_matching(statement_id: str) -> dict[str, Any]:
     matched = 0
     total_lines = 0
     if db_cursor is not None:
@@ -1164,12 +1344,23 @@ def process_matching(statement_id: str) -> dict[str, Any]:
             ),
         )
 
+    _history(
+        statement_id,
+        job="invoice_matching",
+        status="success",
+        ai_stage_name="Invoice-MatchingSummary",
+        log_text=f"Matched {matched} of {total_lines} invoice lines",
+    )
+
     return {
         "statement_id": statement_id,
         "matched": matched,
         "total": total_lines,
         "processing_ok": processing_ok,
     }
+
+
+process_matching = process_invoice_matching
 
 
 @celery_app.task

--- a/backend/src/services/tasks.py
+++ b/backend/src/services/tasks.py
@@ -1360,9 +1360,16 @@ def process_invoice_matching(statement_id: str) -> dict[str, Any]:
     }
 
 
-process_matching = process_invoice_matching
+import warnings
 
-
+def process_matching(*args, **kwargs):
+    warnings.warn(
+        "process_matching is deprecated and will be removed in a future release. "
+        "Please use process_invoice_matching instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return process_invoice_matching(*args, **kwargs)
 @celery_app.task
 def hello(name):
     print(f"Hello, {name}!")

--- a/backend/tests/unit/test_tasks_invoice_pipeline.py
+++ b/backend/tests/unit/test_tasks_invoice_pipeline.py
@@ -1,0 +1,83 @@
+import pytest
+
+from services import tasks
+
+
+class StubDelayTask:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def delay(self, identifier: str) -> None:
+        self.calls.append(identifier)
+
+
+def test_process_ocr_routes_invoice_pages(monkeypatch: pytest.MonkeyPatch) -> None:
+    stub_ai = StubDelayTask()
+    monkeypatch.setattr(tasks, "process_invoice_ai_extraction", stub_ai)
+
+    class FailPipeline:
+        def delay(self, *_args, **_kwargs):
+            raise AssertionError("receipt pipeline should not be triggered for invoices")
+
+    monkeypatch.setattr(tasks, "process_ai_pipeline", FailPipeline())
+    monkeypatch.setattr(tasks, "_get_file_type", lambda fid: "invoice_page")
+    monkeypatch.setattr(tasks, "_get_invoice_parent_id", lambda fid, ft: "inv-1")
+    monkeypatch.setattr(tasks, "_update_file_fields", lambda *args, **kwargs: True)
+    monkeypatch.setattr(tasks, "_update_file_status", lambda *args, **kwargs: True)
+    monkeypatch.setattr(tasks, "_invoice_page_progress", lambda invoice_id: (1, 1))
+    monkeypatch.setattr(tasks, "_history", lambda *args, **kwargs: None)
+    monkeypatch.setattr(tasks, "transition_processing_status", lambda *args, **kwargs: True)
+    monkeypatch.setattr(tasks, "transition_document_status", lambda *args, **kwargs: True)
+    monkeypatch.setattr(tasks, "run_ocr", lambda fid, base: {"text": "hello"})
+
+    result = tasks.process_ocr("page-1")
+
+    assert result["invoice_id"] == "inv-1"
+    assert result["pages_completed"] == 1
+    assert result["pages_total"] == 1
+    assert stub_ai.calls == ["inv-1"]
+
+
+def test_process_ocr_receipt_still_triggers_pipeline(monkeypatch: pytest.MonkeyPatch) -> None:
+    pipeline_calls: list[str] = []
+
+    class StubPipeline:
+        def delay(self, file_id: str) -> None:
+            pipeline_calls.append(file_id)
+
+    monkeypatch.setattr(tasks, "process_ai_pipeline", StubPipeline())
+    monkeypatch.setattr(tasks, "_get_file_type", lambda fid: "receipt")
+    monkeypatch.setattr(tasks, "_get_invoice_parent_id", lambda fid, ft: None)
+    monkeypatch.setattr(tasks, "_update_file_fields", lambda *args, **kwargs: True)
+    monkeypatch.setattr(tasks, "_update_file_status", lambda *args, **kwargs: True)
+    monkeypatch.setattr(tasks, "_history", lambda *args, **kwargs: None)
+    monkeypatch.setattr(tasks, "run_ocr", lambda fid, base: {"text": "hello"})
+
+    result = tasks.process_ocr("receipt-1")
+
+    assert result["status"] == "ocr_done"
+    assert pipeline_calls == ["receipt-1"]
+
+
+def test_process_ocr_invoice_failure_marks_processing(monkeypatch: pytest.MonkeyPatch) -> None:
+    failure_calls: list[tuple[str, str | None]] = []
+
+    def record_failure(invoice_id: str, error: str | None) -> None:
+        failure_calls.append((invoice_id, error))
+
+    monkeypatch.setattr(tasks, "_get_file_type", lambda fid: "invoice")
+    monkeypatch.setattr(tasks, "_get_invoice_parent_id", lambda fid, ft: "inv-2")
+    monkeypatch.setattr(tasks, "_update_file_status", lambda *args, **kwargs: True)
+    monkeypatch.setattr(tasks, "_history", lambda *args, **kwargs: None)
+    monkeypatch.setattr(tasks, "_fail_invoice_processing", record_failure)
+    monkeypatch.setattr(tasks, "transition_processing_status", lambda *args, **kwargs: True)
+
+    def failing_run_ocr(_fid: str, _base: str) -> dict[str, str]:
+        raise RuntimeError("ocr boom")
+
+    monkeypatch.setattr(tasks, "run_ocr", failing_run_ocr)
+
+    result = tasks.process_ocr("inv-2")
+
+    assert result["ok"] is False
+    assert failure_calls == [("inv-2", "RuntimeError: ocr boom")]


### PR DESCRIPTION
## Summary
- branch the OCR task based on file type so invoice pages enqueue the invoice pipeline with dedicated logging
- add invoice AI extraction and matching task stubs that hand off to the matching queue and emit invoice-specific history records
- cover the new routing logic with unit tests for invoice success, invoice failure, and receipt regression protection

## Testing
- pytest backend/tests/unit/test_tasks_invoice_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68e1158c9e7483249b8ae3146296daa0