### PR TITLE
Fix invoice OCR misclassification

### DIFF
--- a/backend/src/models/ai_processing.py
+++ b/backend/src/models/ai_processing.py
@@ -16,12 +16,12 @@ class UnifiedFileBase(BaseModel):
     )
     purchase_datetime: Optional[datetime] = None
     expense_type: Optional[Literal["personal", "corporate"]] = None
-    gross_amount_original: Optional[Decimal] = Field(None, decimal_places=2)
-    net_amount_original: Optional[Decimal] = Field(None, decimal_places=2)
-    exchange_rate: Optional[Decimal] = Field(None, decimal_places=6)
+    gross_amount_original: Optional[Decimal] = Field(None, max_digits=18, decimal_places=2)
+    net_amount_original: Optional[Decimal] = Field(None, max_digits=18, decimal_places=2)
+    exchange_rate: Optional[Decimal] = Field(None, max_digits=18, decimal_places=6)
     currency: Optional[str] = Field(None, max_length=222)
-    gross_amount_sek: Optional[Decimal] = Field(None, decimal_places=2)
-    net_amount_sek: Optional[Decimal] = Field(None, decimal_places=2)
+    gross_amount_sek: Optional[Decimal] = Field(None, max_digits=18, decimal_places=2)
+    net_amount_sek: Optional[Decimal] = Field(None, max_digits=18, decimal_places=2)
     ai_status: Optional[str] = Field(None, max_length=32)
     ai_confidence: Optional[float] = Field(None, ge=0.0, le=1.0)
     mime_type: Optional[str] = Field(None, max_length=222)
@@ -55,13 +55,13 @@ class ReceiptItem(BaseModel):
     article_id: str = Field(max_length=222)
     name: str = Field(max_length=222)
     number: int = Field(gt=0, description="Quantity of items")
-    item_price_ex_vat: Optional[Decimal] = Field(None, decimal_places=2)
-    item_price_inc_vat: Optional[Decimal] = Field(None, decimal_places=2)
-    item_total_price_ex_vat: Optional[Decimal] = Field(None, decimal_places=2)
-    item_total_price_inc_vat: Optional[Decimal] = Field(None, decimal_places=2)
+    item_price_ex_vat: Optional[Decimal] = Field(None, max_digits=18, decimal_places=2)
+    item_price_inc_vat: Optional[Decimal] = Field(None, max_digits=18, decimal_places=2)
+    item_total_price_ex_vat: Optional[Decimal] = Field(None, max_digits=18, decimal_places=2)
+    item_total_price_inc_vat: Optional[Decimal] = Field(None, max_digits=18, decimal_places=2)
     currency: str = Field(default="SEK", max_length=11)
-    vat: Optional[Decimal] = Field(None, decimal_places=2)
-    vat_percentage: Optional[Decimal] = Field(None, decimal_places=6)
+    vat: Optional[Decimal] = Field(None, max_digits=18, decimal_places=2)
+    vat_percentage: Optional[Decimal] = Field(None, max_digits=18, decimal_places=6)
 
 
 class Company(BaseModel):
@@ -84,7 +84,7 @@ class CreditCardInvoiceMain(BaseModel):
     invoice_number: str = Field(max_length=64)
     card_number_masked: str = Field(max_length=20)
     cardholder_name: str = Field(max_length=200)
-    total_amount_sek: Decimal = Field(decimal_places=2)
+    total_amount_sek: Decimal = Field(max_digits=18, decimal_places=2)
     payment_due_date: datetime
     invoice_period_start: datetime
     invoice_period_end: datetime
@@ -103,13 +103,13 @@ class CreditCardInvoiceItem(BaseModel):
     mcc: Optional[str] = Field(None, max_length=4, description="Merchant Category Code")
     description: Optional[str] = None
     currency_original: str = Field(max_length=3, description="ISO currency code")
-    amount_original: Decimal = Field(decimal_places=2)
-    exchange_rate: Optional[Decimal] = Field(None, decimal_places=6)
-    amount_sek: Decimal = Field(decimal_places=2)
-    vat_rate: Optional[Decimal] = Field(None, decimal_places=2)
-    vat_amount: Optional[Decimal] = Field(None, decimal_places=2)
-    net_amount: Optional[Decimal] = Field(None, decimal_places=2)
-    gross_amount: Decimal = Field(decimal_places=2)
+    amount_original: Decimal = Field(max_digits=18, decimal_places=2)
+    exchange_rate: Optional[Decimal] = Field(None, max_digits=18, decimal_places=6)
+    amount_sek: Decimal = Field(max_digits=18, decimal_places=2)
+    vat_rate: Optional[Decimal] = Field(None, max_digits=18, decimal_places=2)
+    vat_amount: Optional[Decimal] = Field(None, max_digits=18, decimal_places=2)
+    net_amount: Optional[Decimal] = Field(None, max_digits=18, decimal_places=2)
+    gross_amount: Decimal = Field(max_digits=18, decimal_places=2)
     cost_center_override: Optional[str] = Field(None, max_length=100)
     project_code: Optional[str] = Field(None, max_length=100)
 
@@ -169,9 +169,9 @@ class AccountingProposal(BaseModel):
 
     receipt_id: str
     account_code: str = Field(max_length=32, description="Account from chart_of_accounts")
-    debit: Decimal = Field(decimal_places=2, default=Decimal("0.00"))
-    credit: Decimal = Field(decimal_places=2, default=Decimal("0.00"))
-    vat_rate: Optional[Decimal] = Field(None, decimal_places=2)
+    debit: Decimal = Field(max_digits=18, decimal_places=2, default=Decimal("0.00"))
+    credit: Decimal = Field(max_digits=18, decimal_places=2, default=Decimal("0.00"))
+    vat_rate: Optional[Decimal] = Field(None, max_digits=18, decimal_places=2)
     notes: Optional[str] = Field(None, max_length=255)
     item_id: Optional[int] = Field(None, description="Reference to receipt_items.id")
 

--- a/backend/tests/unit/test_tasks_invoice_pipeline.py
+++ b/backend/tests/unit/test_tasks_invoice_pipeline.py
@@ -1,0 +1,90 @@
+import pytest
+
+from services import tasks
+
+
+class StubDelayTask:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def delay(self, identifier: str) -> None:
+        self.calls.append(identifier)
+
+
+def test_process_ocr_routes_invoice_pages(monkeypatch: pytest.MonkeyPatch) -> None:
+    stub_ai = StubDelayTask()
+    monkeypatch.setattr(tasks, "process_invoice_ai_extraction", stub_ai)
+
+    class FailPipeline:
+        def delay(self, *_args, **_kwargs):
+            raise AssertionError("receipt pipeline should not be triggered for invoices")
+
+    monkeypatch.setattr(tasks, "process_ai_pipeline", FailPipeline())
+    monkeypatch.setattr(tasks, "_get_file_type", lambda fid: "invoice_page")
+    monkeypatch.setattr(tasks, "_get_invoice_parent_id", lambda fid, ft: "inv-1")
+    monkeypatch.setattr(tasks, "_update_file_fields", lambda *args, **kwargs: True)
+    monkeypatch.setattr(tasks, "_update_file_status", lambda *args, **kwargs: True)
+    monkeypatch.setattr(tasks, "_invoice_page_progress", lambda invoice_id: (1, 1))
+    monkeypatch.setattr(tasks, "_history", lambda *args, **kwargs: None)
+    monkeypatch.setattr(tasks, "transition_processing_status", lambda *args, **kwargs: True)
+    monkeypatch.setattr(tasks, "transition_document_status", lambda *args, **kwargs: True)
+    monkeypatch.setattr(tasks, "run_ocr", lambda fid, base: {"text": "hello"})
+
+    result = tasks.process_ocr("page-1")
+
+    assert result["invoice_id"] == "inv-1"
+    assert result["pages_completed"] == 1
+    assert result["pages_total"] == 1
+    assert stub_ai.calls == ["inv-1"]
+
+
+def test_process_ocr_receipt_still_triggers_pipeline(monkeypatch: pytest.MonkeyPatch) -> None:
+    pipeline_calls: list[str] = []
+
+    class StubPipeline:
+        def delay(self, file_id: str) -> None:
+            pipeline_calls.append(file_id)
+
+    monkeypatch.setattr(tasks, "process_ai_pipeline", StubPipeline())
+    monkeypatch.setattr(tasks, "_get_file_type", lambda fid: "receipt")
+    monkeypatch.setattr(tasks, "_get_invoice_parent_id", lambda fid, ft: None)
+    monkeypatch.setattr(tasks, "_update_file_fields", lambda *args, **kwargs: True)
+    monkeypatch.setattr(tasks, "_update_file_status", lambda *args, **kwargs: True)
+    monkeypatch.setattr(tasks, "_history", lambda *args, **kwargs: None)
+    monkeypatch.setattr(tasks, "run_ocr", lambda fid, base: {"text": "hello"})
+
+    result = tasks.process_ocr("receipt-1")
+
+    assert result["status"] == "ocr_done"
+    assert pipeline_calls == ["receipt-1"]
+
+
+def test_process_ocr_invoice_failure_marks_processing(monkeypatch: pytest.MonkeyPatch) -> None:
+    failure_calls: list[tuple[str, str | None]] = []
+
+    def record_failure(invoice_id: str, error: str | None) -> None:
+        failure_calls.append((invoice_id, error))
+
+    monkeypatch.setattr(tasks, "_get_file_type", lambda fid: "invoice")
+    monkeypatch.setattr(tasks, "_get_invoice_parent_id", lambda fid, ft: "inv-2")
+    monkeypatch.setattr(tasks, "_update_file_status", lambda *args, **kwargs: True)
+    monkeypatch.setattr(tasks, "_history", lambda *args, **kwargs: None)
+    monkeypatch.setattr(tasks, "_fail_invoice_processing", record_failure)
+    monkeypatch.setattr(tasks, "transition_processing_status", lambda *args, **kwargs: True)
+
+    def failing_run_ocr(_fid: str, _base: str) -> dict[str, str]:
+        raise RuntimeError("ocr boom")
+
+    monkeypatch.setattr(tasks, "run_ocr", failing_run_ocr)
+
+    result = tasks.process_ocr("inv-2")
+
+    assert result["ok"] is False
+    assert failure_calls == [("inv-2", "RuntimeError: ocr boom")]
+
+
+def test_get_invoice_parent_id_ignores_receipts(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(tasks, "db_cursor", None)
+
+    assert tasks._get_invoice_parent_id("receipt-1", "receipt") is None
+    assert tasks._get_invoice_parent_id("something", None) is None


### PR DESCRIPTION
## Summary
- restrict invoice parent lookup to invoice pages, relax OCR transition guards, and keep invoice receipts on the correct pipeline
- add invoice AI extraction/matching orchestration hooks and failure handling in the OCR flow
- add decimal max_digits constraints to AI models and create unit coverage for the invoice OCR router

## Testing
- pytest backend/tests/unit/test_tasks_invoice_pipeline.py

Fixes #36

------
https://chatgpt.com/codex/tasks/task_e_68e11ed8481c8324af830259a29eb7a4