### PR TITLE
Fix invoice state lifecycle regression

### DIFF
--- a/backend/tests/unit/test_invoice_tasks.py
+++ b/backend/tests/unit/test_invoice_tasks.py
@@ -1,0 +1,63 @@
+import pytest
+
+
+@pytest.fixture()
+def task_module(monkeypatch):
+    from services import tasks as tasks_module
+
+    monkeypatch.setattr(tasks_module, "_history", lambda *args, **kwargs: None)
+    return tasks_module
+
+
+def test_process_invoice_document_updates_state_and_schedules(monkeypatch, task_module):
+    recorded = {"processing": [], "document": [], "metadata": [], "scheduled": []}
+
+    def fake_transition_processing_status(document_id, target, allowed):
+        recorded["processing"].append((document_id, target, tuple(allowed)))
+        if target == task_module.InvoiceProcessingStatus.AI_PROCESSING:
+            return True
+        if target == task_module.InvoiceProcessingStatus.READY_FOR_MATCHING:
+            return True
+        return False
+
+    def fake_transition_document_status(document_id, target, allowed):
+        recorded["document"].append((document_id, target, tuple(allowed)))
+        return True
+
+    monkeypatch.setattr(task_module, "transition_processing_status", fake_transition_processing_status)
+    monkeypatch.setattr(task_module, "transition_document_status", fake_transition_document_status)
+    monkeypatch.setattr(
+        task_module,
+        "_set_invoice_metadata_field",
+        lambda document_id, key, value: recorded["metadata"].append((document_id, key, value)),
+    )
+
+    class StubTask:
+        def delay(self, document_id):
+            recorded["scheduled"].append(document_id)
+
+        def run(self, document_id):
+            recorded["scheduled"].append(document_id)
+
+    monkeypatch.setattr(task_module, "process_invoice_matching", StubTask())
+
+    result = task_module.process_invoice_document("doc-123")
+
+    assert result["ok"] is True
+    assert result["status"] == task_module.InvoiceProcessingStatus.READY_FOR_MATCHING.value
+    assert [entry[1] for entry in recorded["processing"]] == [
+        task_module.InvoiceProcessingStatus.AI_PROCESSING,
+        task_module.InvoiceProcessingStatus.READY_FOR_MATCHING,
+    ]
+    assert recorded["metadata"] == [
+        ("doc-123", "processing_status", task_module.InvoiceProcessingStatus.AI_PROCESSING.value),
+        ("doc-123", "processing_status", task_module.InvoiceProcessingStatus.READY_FOR_MATCHING.value),
+    ]
+    assert recorded["document"] == [
+        (
+            "doc-123",
+            task_module.InvoiceDocumentStatus.MATCHING,
+            (task_module.InvoiceDocumentStatus.IMPORTED,),
+        )
+    ]
+    assert recorded["scheduled"] == ["doc-123"]


### PR DESCRIPTION
## Summary
- ensure the FirstCard invoice upload endpoint seeds invoice_documents using the new enum states and surfaces processing metadata in the statements listing
- add orchestration helpers so OCR completion advances invoice processing, updates metadata, and queues the invoice document and matching Celery tasks
- update regression coverage for the revised state machine and add a focused unit test for process_invoice_document scheduling

## Testing
- pytest backend/tests/integration/test_invoice_upload_status.py backend/tests/integration/test_firstcard_invoice_flow.py backend/tests/unit/test_invoice_tasks.py

------
https://chatgpt.com/codex/tasks/task_e_68e11e95d7148324972d03c52f5c099a