### PR TITLE
Address invoice OCR orchestration regressions (issue #41)

### DIFF
--- a/backend/src/models/ai_processing.py
+++ b/backend/src/models/ai_processing.py
@@ -3,7 +3,11 @@ from datetime import datetime
 from decimal import Decimal
 from typing import Optional, List, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, condecimal
+
+
+Decimal18_2 = condecimal(max_digits=18, decimal_places=2)
+Decimal12_6 = condecimal(max_digits=12, decimal_places=6)
 
 
 class UnifiedFileBase(BaseModel):
@@ -16,12 +20,12 @@ class UnifiedFileBase(BaseModel):
     )
     purchase_datetime: Optional[datetime] = None
     expense_type: Optional[Literal["personal", "corporate"]] = None
-    gross_amount_original: Optional[Decimal] = Field(None, decimal_places=2)
-    net_amount_original: Optional[Decimal] = Field(None, decimal_places=2)
-    exchange_rate: Optional[Decimal] = Field(None, decimal_places=6)
+    gross_amount_original: Optional[Decimal18_2] = None
+    net_amount_original: Optional[Decimal18_2] = None
+    exchange_rate: Optional[Decimal12_6] = None
     currency: Optional[str] = Field(None, max_length=222)
-    gross_amount_sek: Optional[Decimal] = Field(None, decimal_places=2)
-    net_amount_sek: Optional[Decimal] = Field(None, decimal_places=2)
+    gross_amount_sek: Optional[Decimal18_2] = None
+    net_amount_sek: Optional[Decimal18_2] = None
     ai_status: Optional[str] = Field(None, max_length=32)
     ai_confidence: Optional[float] = Field(None, ge=0.0, le=1.0)
     mime_type: Optional[str] = Field(None, max_length=222)
@@ -55,13 +59,13 @@ class ReceiptItem(BaseModel):
     article_id: str = Field(max_length=222)
     name: str = Field(max_length=222)
     number: int = Field(gt=0, description="Quantity of items")
-    item_price_ex_vat: Optional[Decimal] = Field(None, decimal_places=2)
-    item_price_inc_vat: Optional[Decimal] = Field(None, decimal_places=2)
-    item_total_price_ex_vat: Optional[Decimal] = Field(None, decimal_places=2)
-    item_total_price_inc_vat: Optional[Decimal] = Field(None, decimal_places=2)
+    item_price_ex_vat: Optional[Decimal18_2] = None
+    item_price_inc_vat: Optional[Decimal18_2] = None
+    item_total_price_ex_vat: Optional[Decimal18_2] = None
+    item_total_price_inc_vat: Optional[Decimal18_2] = None
     currency: str = Field(default="SEK", max_length=11)
-    vat: Optional[Decimal] = Field(None, decimal_places=2)
-    vat_percentage: Optional[Decimal] = Field(None, decimal_places=6)
+    vat: Optional[Decimal18_2] = None
+    vat_percentage: Optional[Decimal12_6] = None
 
 
 class Company(BaseModel):
@@ -84,7 +88,7 @@ class CreditCardInvoiceMain(BaseModel):
     invoice_number: str = Field(max_length=64)
     card_number_masked: str = Field(max_length=20)
     cardholder_name: str = Field(max_length=200)
-    total_amount_sek: Decimal = Field(decimal_places=2)
+    total_amount_sek: Decimal18_2
     payment_due_date: datetime
     invoice_period_start: datetime
     invoice_period_end: datetime
@@ -103,13 +107,13 @@ class CreditCardInvoiceItem(BaseModel):
     mcc: Optional[str] = Field(None, max_length=4, description="Merchant Category Code")
     description: Optional[str] = None
     currency_original: str = Field(max_length=3, description="ISO currency code")
-    amount_original: Decimal = Field(decimal_places=2)
-    exchange_rate: Optional[Decimal] = Field(None, decimal_places=6)
-    amount_sek: Decimal = Field(decimal_places=2)
-    vat_rate: Optional[Decimal] = Field(None, decimal_places=2)
-    vat_amount: Optional[Decimal] = Field(None, decimal_places=2)
-    net_amount: Optional[Decimal] = Field(None, decimal_places=2)
-    gross_amount: Decimal = Field(decimal_places=2)
+    amount_original: Decimal18_2
+    exchange_rate: Optional[Decimal12_6] = None
+    amount_sek: Decimal18_2
+    vat_rate: Optional[Decimal18_2] = None
+    vat_amount: Optional[Decimal18_2] = None
+    net_amount: Optional[Decimal18_2] = None
+    gross_amount: Decimal18_2
     cost_center_override: Optional[str] = Field(None, max_length=100)
     project_code: Optional[str] = Field(None, max_length=100)
 
@@ -169,9 +173,9 @@ class AccountingProposal(BaseModel):
 
     receipt_id: str
     account_code: str = Field(max_length=32, description="Account from chart_of_accounts")
-    debit: Decimal = Field(decimal_places=2, default=Decimal("0.00"))
-    credit: Decimal = Field(decimal_places=2, default=Decimal("0.00"))
-    vat_rate: Optional[Decimal] = Field(None, decimal_places=2)
+    debit: Decimal18_2 = Field(default=Decimal("0.00"))
+    credit: Decimal18_2 = Field(default=Decimal("0.00"))
+    vat_rate: Optional[Decimal18_2] = None
     notes: Optional[str] = Field(None, max_length=255)
     item_id: Optional[int] = Field(None, description="Reference to receipt_items.id")
 

--- a/backend/tests/integration/test_invoice_upload_status.py
+++ b/backend/tests/integration/test_invoice_upload_status.py
@@ -1,5 +1,7 @@
 import io
 import json
+import sys
+import types
 import uuid
 from pathlib import Path
 from typing import Any, Dict, List
@@ -108,6 +110,10 @@ class FakeDB:
                 "status": status,
                 "metadata_json": metadata_json,
             }
+        elif statement.startswith("update invoice_documents set metadata_json="):
+            metadata_json, doc_id = params
+            if doc_id in self.invoice_documents:
+                self.invoice_documents[doc_id]["metadata_json"] = metadata_json
         elif statement.startswith("update invoice_documents set status="):
             status, metadata_json, doc_id = params
             if doc_id in self.invoice_documents:
@@ -119,6 +125,10 @@ class FakeDB:
             self._results = [
                 (doc["status"], doc["metadata_json"])
             ] if doc else []
+        elif statement.startswith("select metadata_json from invoice_documents"):
+            doc_id = params[0]
+            doc = self.invoice_documents.get(doc_id)
+            self._results = [(doc["metadata_json"],)] if doc else []
         elif statement.startswith("select count(1), sum(case when match_status") and "from invoice_lines" in statement:
             invoice_id = params[0]
             lines = [ln for ln in self.invoice_lines if ln["invoice_id"] == invoice_id]
@@ -177,6 +187,30 @@ class FakeDB:
 def app(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Flask:
     monkeypatch.setenv("DB_AUTO_MIGRATE", "0")
     monkeypatch.setenv("STORAGE_DIR", str(tmp_path / "storage"))
+
+    class _LimiterStub:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        def limit(self, *args: Any, **kwargs: Any):
+            def decorator(func):
+                return func
+
+            return decorator
+
+        def init_app(self, app: Flask) -> None:  # type: ignore[name-defined]
+            return None
+
+    monkeypatch.setitem(
+        sys.modules,
+        "flask_limiter",
+        types.SimpleNamespace(Limiter=lambda *args, **kwargs: _LimiterStub()),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "flask_limiter.util",
+        types.SimpleNamespace(get_remote_address=lambda *args, **kwargs: "127.0.0.1"),
+    )
     from api.app import app as flask_app
     return flask_app
 
@@ -194,6 +228,7 @@ def _patch_db(monkeypatch: pytest.MonkeyPatch, fake: FakeDB) -> None:
 
 def _stub_tasks(monkeypatch: pytest.MonkeyPatch) -> list[str]:
     from api import reconciliation_firstcard as module
+    from services import tasks as tasks_module
 
     calls: list[str] = []
 
@@ -202,6 +237,8 @@ def _stub_tasks(monkeypatch: pytest.MonkeyPatch) -> list[str]:
             calls.append(file_id)
 
     monkeypatch.setattr(module, "process_ocr", StubTask())
+    monkeypatch.setattr(tasks_module, "_maybe_advance_invoice_from_file", lambda *args, **kwargs: None)
+    monkeypatch.setattr(tasks_module, "_set_invoice_metadata_field", lambda *args, **kwargs: None)
     return calls
 
 

--- a/backend/tests/unit/test_invoice_tasks.py
+++ b/backend/tests/unit/test_invoice_tasks.py
@@ -1,0 +1,139 @@
+import json
+
+import pytest
+
+from services import tasks
+from services.invoice_status import InvoiceProcessingStatus
+
+
+def test_get_invoice_parent_id_filters_non_invoice(monkeypatch: pytest.MonkeyPatch) -> None:
+    info_map = {
+        "receipt-1": {"id": "receipt-1", "file_type": "receipt", "original_file_id": "receipt-1", "other_data": {}},
+        "page-1": {"id": "page-1", "file_type": "invoice_page", "original_file_id": "inv-1", "other_data": {}},
+        "inv-1": {"id": "inv-1", "file_type": "invoice", "original_file_id": "inv-1", "other_data": {}},
+    }
+
+    monkeypatch.setattr(tasks, "_load_unified_file_info", lambda fid: info_map.get(fid))
+
+    assert tasks._get_invoice_parent_id("receipt-1") is None
+    assert tasks._get_invoice_parent_id("page-1") == "inv-1"
+    assert tasks._get_invoice_parent_id("inv-1") == "inv-1"
+
+
+def test_maybe_advance_invoice_tracks_progress(monkeypatch: pytest.MonkeyPatch) -> None:
+    metadata_store: dict[str, dict[str, object]] = {
+        "inv-1": {
+            "page_ids": ["page-1", "page-2"],
+            "page_count": 2,
+            "processing_status": "ocr_pending",
+        }
+    }
+    info_map = {
+        "page-1": {"id": "page-1", "file_type": "invoice_page", "original_file_id": "inv-1", "other_data": {}},
+        "page-2": {"id": "page-2", "file_type": "invoice_page", "original_file_id": "inv-1", "other_data": {}},
+    }
+    transitions: list[tuple[str, InvoiceProcessingStatus, tuple[InvoiceProcessingStatus, ...]]] = []
+    scheduled: list[str] = []
+
+    def load_file(fid: str):
+        return info_map.get(fid)
+
+    def load_metadata(invoice_id: str):
+        entry = metadata_store.get(invoice_id)
+        return json.loads(json.dumps(entry)) if entry is not None else {}
+
+    def update_metadata(invoice_id: str, metadata: dict[str, object]) -> bool:
+        metadata_store[invoice_id] = json.loads(json.dumps(metadata))
+        return True
+
+    def set_field(invoice_id: str, field: str, value: object):
+        metadata_store.setdefault(invoice_id, {})[field] = value
+        return metadata_store[invoice_id]
+
+    def enqueue(invoice_id: str) -> bool:
+        scheduled.append(invoice_id)
+        return True
+
+    def transition(invoice_id: str, target: InvoiceProcessingStatus, allowed: tuple[InvoiceProcessingStatus, ...]) -> bool:
+        transitions.append((invoice_id, target, allowed))
+        return True
+
+    monkeypatch.setattr(tasks, "_load_unified_file_info", load_file)
+    monkeypatch.setattr(tasks, "_load_invoice_metadata", load_metadata)
+    monkeypatch.setattr(tasks, "_update_invoice_metadata", update_metadata)
+    monkeypatch.setattr(tasks, "_set_invoice_metadata_field", set_field)
+    monkeypatch.setattr(tasks, "_enqueue_invoice_document", enqueue)
+    monkeypatch.setattr(tasks, "transition_processing_status", transition)
+
+    tasks._maybe_advance_invoice_from_file("page-1", success=True)
+
+    meta_first = metadata_store["inv-1"]
+    page_status_first = meta_first.get("page_status") or {}
+    assert page_status_first.get("page-1") == "ocr_done"
+    assert meta_first.get("ocr_completed_pages") == 1
+    assert meta_first.get("processing_status") == InvoiceProcessingStatus.OCR_PENDING.value
+    assert len(transitions) == 1
+    assert transitions[0][1] == InvoiceProcessingStatus.OCR_PENDING
+    assert scheduled == []
+
+    tasks._maybe_advance_invoice_from_file("page-2", success=True)
+
+    meta_second = metadata_store["inv-1"]
+    assert meta_second.get("ocr_completed_pages") == 2
+    assert meta_second.get("processing_status") == InvoiceProcessingStatus.OCR_DONE.value
+    assert meta_second.get("invoice_document_scheduled") is True
+    assert scheduled == ["inv-1"]
+    assert transitions[-1][1] == InvoiceProcessingStatus.OCR_DONE
+    allowed_states = transitions[-1][2]
+    assert InvoiceProcessingStatus.OCR_DONE in allowed_states
+
+
+def test_maybe_advance_invoice_failure_marks_failed(monkeypatch: pytest.MonkeyPatch) -> None:
+    metadata_store: dict[str, dict[str, object]] = {
+        "inv-2": {
+            "page_ids": ["page-x"],
+            "page_count": 1,
+        }
+    }
+    info_map = {
+        "page-x": {"id": "page-x", "file_type": "invoice_page", "original_file_id": "inv-2", "other_data": {}},
+    }
+    transitions: list[InvoiceProcessingStatus] = []
+    scheduled: list[str] = []
+
+    def load_metadata(invoice_id: str):
+        entry = metadata_store.get(invoice_id)
+        return json.loads(json.dumps(entry)) if entry is not None else {}
+
+    def update_metadata(invoice_id: str, metadata: dict[str, object]) -> bool:
+        metadata_store[invoice_id] = json.loads(json.dumps(metadata))
+        return True
+
+    def set_field(invoice_id: str, field: str, value: object):
+        metadata_store.setdefault(invoice_id, {})[field] = value
+        return metadata_store[invoice_id]
+
+    def enqueue(invoice_id: str) -> bool:
+        scheduled.append(invoice_id)
+        return True
+
+    monkeypatch.setattr(tasks, "_load_unified_file_info", lambda fid: info_map.get(fid))
+    monkeypatch.setattr(tasks, "_load_invoice_metadata", load_metadata)
+    monkeypatch.setattr(tasks, "_update_invoice_metadata", update_metadata)
+    monkeypatch.setattr(tasks, "_set_invoice_metadata_field", set_field)
+    monkeypatch.setattr(tasks, "_enqueue_invoice_document", enqueue)
+
+    def transition(invoice_id: str, target: InvoiceProcessingStatus, allowed: tuple[InvoiceProcessingStatus, ...]) -> bool:
+        transitions.append(target)
+        return True
+
+    monkeypatch.setattr(tasks, "transition_processing_status", transition)
+
+    tasks._maybe_advance_invoice_from_file("page-x", success=False)
+
+    meta = metadata_store["inv-2"]
+    page_status = meta.get("page_status") or {}
+    assert page_status.get("page-x") == "ocr_failed"
+    assert meta.get("processing_status") == InvoiceProcessingStatus.FAILED.value
+    assert InvoiceProcessingStatus.FAILED in transitions
+    assert scheduled == []


### PR DESCRIPTION
## Summary
- replace Pydantic decimal field constraints with `condecimal`-based aliases so the AI processing models import cleanly under Pydantic 2.x
- add invoice OCR helper utilities in `tasks.py` to update metadata, relax transition guards, and only schedule invoice document processing when all pages are finished
- extend invoice upload integration coverage with limiter stubs/metadata handling and add unit tests for the new helpers

## Testing
- pytest backend/tests/unit/test_invoice_tasks.py
- pytest backend/tests/integration/test_invoice_upload_status.py

------
https://chatgpt.com/codex/tasks/task_e_68e13612a1c083249873276d751fb44e